### PR TITLE
display user activity on graphs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "editor.minimap.enabled": false,
+  // "editor.minimap.enabled": false,
   "editor.insertSpaces": false,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true

--- a/thoughtbubble-api/controllers/activityController.ts
+++ b/thoughtbubble-api/controllers/activityController.ts
@@ -17,9 +17,10 @@ class ActivityController {
       const userIdx = user?.id;
       const userActivity = await getRepository(Activity)
         .createQueryBuilder('activity')
+        // .leftJoinAndSelect('activity.project', 'project')
         .where('activity.user = :user', { user: userIdx })
         .getMany();
-
+      // console.log(JSON.stringify(userActivity));
       res.send(JSON.stringify(userActivity));
     } catch (err) {
       console.error(this.location, err);

--- a/thoughtbubble-api/controllers/projectController.ts
+++ b/thoughtbubble-api/controllers/projectController.ts
@@ -36,7 +36,6 @@ class ProjectsController extends ControllerHelper {
         const projectThoughts2 = projectThoughts as any[];
         data[i].projectThoughts = projectThoughts2; // thoughts is a keyword
       }
-
       res.send(data).status(200);
     } catch (err) {
       console.error(this.location, err);

--- a/thoughtbubble-api/entities/Activity.ts
+++ b/thoughtbubble-api/entities/Activity.ts
@@ -10,8 +10,11 @@ export class Activity extends BaseEntity {
   @Column()
   activityDate!: Date;
 
+  @Column()
+  userId!: string;
+
   @ManyToOne(() => User, (user) => user.activity, { onDelete: 'CASCADE' })
-  // @JoinColumn({ name: 'userId' })
+  @JoinColumn({ name: 'userId' })
   user!: User;
 
   @Column()

--- a/thoughtbubble-api/entities/Activity.ts
+++ b/thoughtbubble-api/entities/Activity.ts
@@ -10,19 +10,14 @@ export class Activity extends BaseEntity {
   @Column()
   activityDate!: Date;
 
-  // @OneToOne(() => User)
-  // @JoinColumn()
-  // user!: User; // typeorm api turns project -> projectId
-
-  // @OneToOne(() => Project)
-  // @JoinColumn()
-  // project!: Project; // typeorm api turns project -> projectId
-
   @ManyToOne(() => User, (user) => user.activity, { onDelete: 'CASCADE' })
   // @JoinColumn({ name: 'userId' })
   user!: User;
 
+  @Column()
+  projectId!: string;
+
   @ManyToOne(() => Project, (project) => project.activity, { onDelete: 'CASCADE' })
-  // @JoinColumn({ name: 'userId' })
+  @JoinColumn({ name: 'projectId' })
   project!: Project;
 }

--- a/thoughtbubble-mobile/src/components/StatsHomeScreen.tsx
+++ b/thoughtbubble-mobile/src/components/StatsHomeScreen.tsx
@@ -98,7 +98,7 @@ export const StatsHomeScreen: FC<StatsHomeScreenProps> = ({ navigation }) => {
               <CarouselCard
                 style={isDarkMode ? null : styles.carouselCard}
                 key={proj.id}
-                onPress={() => navigation.navigate('StatsForProject', { projectId: proj.id })}
+                onPress={() => navigation.navigate('Project Analytics', { projectId: proj.id })}
                 activeOpacity={0.7} // 0.2 default
               >
                 <CarouselCardHeaderText>{proj.projectName}</CarouselCardHeaderText>

--- a/thoughtbubble-mobile/src/components/StatsHomeScreen.tsx
+++ b/thoughtbubble-mobile/src/components/StatsHomeScreen.tsx
@@ -91,14 +91,6 @@ export const StatsHomeScreen: FC<StatsHomeScreenProps> = ({ navigation }) => {
   // remove colored grid
   gridlessGraphTheme.axis.style.grid.stroke = isDarkMode ? '#FFFFFF15' : '#00000015';
 
-  const generateXaxisLabel = (): string => {
-    // x label for graph "mm/dd/yyyy -> mm/dd/yyyy"
-    const xys = userActivityData.graphData.slice(-1 * currRange);
-    const first = DateHelper.dateToMMDDYYY(DateHelper.dayNToDate(xys[0].x));
-    const last = DateHelper.dateToMMDDYYY(DateHelper.dayNToDate(xys[xys.length - 1].x));
-    return `${first}  →  ${last}`;
-  };
-
   const calculateStreak = (): number => {
     // given a set of xy graph coords
     const graphData = [...userActivityData.graphData];
@@ -176,7 +168,7 @@ export const StatsHomeScreen: FC<StatsHomeScreenProps> = ({ navigation }) => {
               tickFormat={() => ''}
               offsetY={50}
               axisLabelComponent={<VictoryLabel dy={16} />}
-              label={generateXaxisLabel()}
+              label={DateHelper.generateXaxisDateLabel(userActivityData.graphData, currRange)}
             />
             <VictoryBar
               events={[

--- a/thoughtbubble-mobile/src/components/StatsHomeScreen.tsx
+++ b/thoughtbubble-mobile/src/components/StatsHomeScreen.tsx
@@ -89,7 +89,6 @@ export const StatsHomeScreen: FC<StatsHomeScreenProps> = ({ navigation }) => {
 
   const gridlessGraphTheme = VictoryTheme.material;
   // remove colored grid
-  // gridlessGraphTheme.axis.style.grid.stroke = 'transparent';
   gridlessGraphTheme.axis.style.grid.stroke = isDarkMode ? '#FFFFFF15' : '#00000015';
 
   const generateXaxisLabel = (): string => {
@@ -117,6 +116,7 @@ export const StatsHomeScreen: FC<StatsHomeScreenProps> = ({ navigation }) => {
 
   return (
     <ThemeProvider theme={theme}>
+      {console.log(userActivityData)}
       <MainContainer>
         <AccountTotalsContainer>
           <AccountTotalsCard>
@@ -488,20 +488,6 @@ const SnackBarContainer = styled.View`
   /* bottom: 0; */
   top: 70px;
 `;
-
-const StreakHeader = styled.View`
-  height: 65px;
-  /* border: 1px solid grey; */
-  flex-direction: row;
-  align-items: center;
-  justify-content: center;
-`;
-
-// const StreakText = styled.Text`
-//   color: ${(props) => props.theme.textOnBackground};
-//   font-size: 20px;
-//   margin-left: 15px;
-// `;
 
 const GraphTitleContainer = styled.View`
   height: 30px;

--- a/thoughtbubble-mobile/src/components/StatsHomeScreen.tsx
+++ b/thoughtbubble-mobile/src/components/StatsHomeScreen.tsx
@@ -2,7 +2,7 @@ import React, { FC, useCallback, useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import styled, { ThemeProvider } from 'styled-components/native';
 import { useFocusEffect } from '@react-navigation/native';
-import { VictoryChart, VictoryTheme, VictoryBar, VictoryLabel } from 'victory-native';
+import { VictoryChart, VictoryTheme, VictoryBar, VictoryLabel, VictoryAxis } from 'victory-native';
 import equal from 'deep-equal';
 import { colors } from '../constants/colors';
 import { RootState } from '../reducers/rootReducer';
@@ -13,8 +13,6 @@ import { DateHelper } from '../utils/dateHelpers';
 import { StyleSheet } from 'react-native';
 import { Button, Snackbar } from 'react-native-paper';
 import { activityRangeMap } from '../constants/activityRanges';
-import { transformFileSync } from '@babel/core';
-import { timeStamp } from 'console';
 
 const { darkMode, lightMode } = colors;
 
@@ -52,6 +50,15 @@ export const StatsHomeScreen: FC<StatsHomeScreenProps> = ({ navigation }) => {
     cardBorder: isDarkMode ? darkMode.dp1 : 'black',
   };
 
+  const generateXaxisLabel = (): string => {
+    // x label for graph "mm/dd/yyyy to mm/dd/yyyy"
+    const xys = userActivityData.graphData.slice(-1 * currRange);
+    const first = DateHelper.dateToMMDDYYY(DateHelper.dayNToDate(xys[0].x));
+    console.log(first, 'first');
+    const last = DateHelper.dateToMMDDYYY(DateHelper.dayNToDate(xys[xys.length - 1].x));
+    return `${first}  →  ${last}`;
+  };
+
   const gridlessGraphTheme = VictoryTheme.material;
   // remove colored grid
   gridlessGraphTheme.axis.style.grid.stroke = 'transparent';
@@ -80,6 +87,24 @@ export const StatsHomeScreen: FC<StatsHomeScreenProps> = ({ navigation }) => {
         </SnackBarContainer>
         <GraphContainer>
           <VictoryChart theme={gridlessGraphTheme} domainPadding={{ x: 25 }} width={450}>
+            <VictoryAxis
+              // y-axis
+              style={
+                {
+                  // axis: { stroke: 'transparent' },
+                  // ticks: { stroke: 'transparent' },
+                  // tickLabels: { fill: 'transparent' },
+                }
+              }
+              dependentAxis
+            />
+            <VictoryAxis
+              // x-axis
+              tickFormat={() => ''}
+              offsetY={50}
+              axisLabelComponent={<VictoryLabel dy={16} />}
+              label={generateXaxisLabel()}
+            />
             <VictoryBar
               events={[
                 {

--- a/thoughtbubble-mobile/src/components/StatsHomeScreen.tsx
+++ b/thoughtbubble-mobile/src/components/StatsHomeScreen.tsx
@@ -11,6 +11,7 @@ import { VictoryLine, VictoryChart, VictoryTheme, VictoryBar, VictoryLabel, Vict
 import { fetchActivityDataAction } from '../actions/fetchActivityAction';
 import equal from 'deep-equal';
 import { DateHelper } from '../utils/dateHelpers';
+import { StyleSheet } from 'react-native';
 
 const { darkMode, lightMode } = colors;
 
@@ -95,6 +96,7 @@ export const StatsHomeScreen: FC<StatsHomeScreenProps> = ({ navigation }) => {
           <CarouselContainer>
             {userProjectsData.map((proj) => (
               <CarouselCard
+                style={isDarkMode ? null : styles.carouselCard}
                 key={proj.id}
                 onPress={() => navigation.navigate('StatsForProject', { projectId: proj.id })}
                 activeOpacity={0.7} // 0.2 default
@@ -144,7 +146,7 @@ const CarouselContainer = styled.View`
 `;
 
 const CarouselCard = styled.TouchableOpacity`
-  border: ${(props) => props.theme.cardBorder};
+  /* border: ${(props) => props.theme.cardBorder}; */
   padding: 10px;
   border-radius: 10px;
   height: 160px;
@@ -152,6 +154,19 @@ const CarouselCard = styled.TouchableOpacity`
   margin: 10px;
   background-color: ${(props) => props.theme.dp1};
 `;
+
+const styles = StyleSheet.create({
+  carouselCard: {
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 1,
+    },
+    shadowOpacity: 0.22,
+    shadowRadius: 2.22,
+    elevation: 3,
+  },
+});
 
 const CarouselCardHeaderText = styled.Text`
   /* text-align: center */

--- a/thoughtbubble-mobile/src/components/StatsHomeScreen.tsx
+++ b/thoughtbubble-mobile/src/components/StatsHomeScreen.tsx
@@ -24,33 +24,27 @@ export const StatsHomeScreen: FC<StatsHomeScreenProps> = ({ navigation }) => {
   const userSub = useSelector((state: RootState) => state.storedUser.sub);
   const userProjectsData = useSelector((state: RootState) => state.userProjectData, equal);
   const userActivityData = useSelector((state: RootState) => state.activity);
-  const [currRange, setCurrRange] = useState<ActivityRanges>('1W');
-  const [sliceLength, setSliceLength] = useState(7);
+  const [currRange, setCurrRange] = useState(activityRangeMap.get('1W'));
 
   const handle1WClick = () => {
-    // setCurrRange(activityRanges['1W']);
-    // setCurrRange('1W');
-    setSliceLength(7);
+    setCurrRange(7);
+    // setCurrRange(activityRangeMap.get('1W'));
   };
   const handle1MClick = () => {
-    // setCurrRange(activityRanges['1M']);
-    // setCurrRange('1M');
-    setSliceLength(30);
+    setCurrRange(30);
+    // setCurrRange(activityRangeMap.get('1W'));
   };
   const handle3MClick = () => {
-    // setCurrRange(activityRanges['3M']);
-    // setCurrRange('3M');
-    setSliceLength(91);
+    setCurrRange(91);
+    // setCurrRange(activityRangeMap.get('1M'));
   };
   const handle6MClick = () => {
-    // setCurrRange(activityRanges['6M']);
-    // setCurrRange('6M');
-    setSliceLength(183);
+    // setCurrRange(activityRangeMap.get('3M'));
+    setCurrRange(183);
   };
   const handle1YClick = () => {
-    // setCurrRange(activityRanges['1Y']);
-    // setCurrRange('1Y');
-    setSliceLength(365);
+    // setCurrRange(activityRangeMap.get('1Y'));
+    setCurrRange(365);
   };
 
   // useEffect(() => {
@@ -98,8 +92,7 @@ export const StatsHomeScreen: FC<StatsHomeScreenProps> = ({ navigation }) => {
               // labelComponent={<VictoryLabel x={20} y={200} angle={-90} text="activity" />}
               labelComponent={<VictoryLabel x={205} y={45} text={`account activity`} />}
               style={{ data: { fill: isDarkMode ? darkMode.primary : lightMode.secondary } }}
-              data={userActivityData.graphData.slice(-1 * activityRangeMap.get(currRange))}
-              // data={userActivityData.graphData.slice(-1 * sliceLength)}
+              data={userActivityData.graphData.slice(-1 * currRange)}
               height={300}
               labels={({ datum }) => {
                 if (!datum.y) return '';
@@ -120,7 +113,7 @@ export const StatsHomeScreen: FC<StatsHomeScreenProps> = ({ navigation }) => {
             compact
             style={styles.btn}
             // color={isDarkMode ? `${darkMode.primary}32` : lightMode.primary}
-            mode={currRange === '1W' ? 'contained' : 'text'}
+            mode={currRange === activityRangeMap.get('1W') ? 'contained' : 'text'}
             onPress={() => handle1WClick()} // and change currrange
             color={`${darkMode.primary}18`}
             labelStyle={{ color: isDarkMode ? darkMode.primary : lightMode.primary }}
@@ -130,7 +123,7 @@ export const StatsHomeScreen: FC<StatsHomeScreenProps> = ({ navigation }) => {
           <Button
             compact
             style={styles.btn}
-            mode={currRange === '1M' ? 'contained' : 'text'}
+            mode={currRange === activityRangeMap.get('1M') ? 'contained' : 'text'}
             onPress={() => handle1MClick()}
             color={`${darkMode.primary}18`}
             labelStyle={{ color: isDarkMode ? darkMode.primary : lightMode.primary }}
@@ -140,7 +133,7 @@ export const StatsHomeScreen: FC<StatsHomeScreenProps> = ({ navigation }) => {
           <Button
             compact
             style={styles.btn}
-            mode={currRange === '3M' ? 'contained' : 'text'}
+            mode={currRange === activityRangeMap.get('3M') ? 'contained' : 'text'}
             onPress={() => handle3MClick()}
             color={`${darkMode.primary}18`}
             labelStyle={{ color: isDarkMode ? darkMode.primary : lightMode.primary }}
@@ -150,7 +143,7 @@ export const StatsHomeScreen: FC<StatsHomeScreenProps> = ({ navigation }) => {
           <Button
             compact
             style={styles.btn}
-            mode={currRange === '6M' ? 'contained' : 'text'}
+            mode={currRange === activityRangeMap.get('6M') ? 'contained' : 'text'}
             onPress={() => handle6MClick()}
             color={`${darkMode.primary}18`}
             labelStyle={{ color: isDarkMode ? darkMode.primary : lightMode.primary }}
@@ -160,7 +153,7 @@ export const StatsHomeScreen: FC<StatsHomeScreenProps> = ({ navigation }) => {
           <Button
             compact
             style={styles.btn}
-            mode={currRange === '1Y' ? 'contained' : 'text'}
+            mode={currRange === activityRangeMap.get('1Y') ? 'contained' : 'text'}
             onPress={() => handle1YClick()}
             color={`${darkMode.primary}18`}
             labelStyle={{ color: isDarkMode ? darkMode.primary : lightMode.primary }}
@@ -189,7 +182,6 @@ export const StatsHomeScreen: FC<StatsHomeScreenProps> = ({ navigation }) => {
           </CarouselContainer>
         </HorizontalScrollView>
       </MainContainer>
-      <Text>{userActivityData.data.length}</Text>
     </ThemeProvider>
   );
 };

--- a/thoughtbubble-mobile/src/components/StatsHomeScreen.tsx
+++ b/thoughtbubble-mobile/src/components/StatsHomeScreen.tsx
@@ -18,11 +18,12 @@ import { useDarkCheck } from '../hooks/useDarkCheck';
 import { StatsHomeScreenProps } from '../interfaces/componentProps';
 import { fetchActivityDataAction } from '../actions/fetchActivityAction';
 import { DateHelper } from '../utils/dateHelpers';
-import { Modal, StyleSheet, Linking, Text, TouchableOpacity } from 'react-native';
-import { Button, IconButton, Snackbar, Paragraph, Divider, ProgressBar } from 'react-native-paper';
+import { Modal, StyleSheet, Linking, Text } from 'react-native';
+import { Button, IconButton, Snackbar, ProgressBar } from 'react-native-paper';
 import { activityRangeMap } from '../constants/activityRanges';
 import { Activity, ProjectShape } from '../interfaces/data';
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
+// folder, folder-information-outline, calender, thought-bubble
 
 const { darkMode, lightMode } = colors;
 
@@ -61,6 +62,14 @@ export const StatsHomeScreen: FC<StatsHomeScreenProps> = ({ navigation }) => {
   useLayoutEffect(() => {
     // add icons in header
     navigation.setOptions({
+      // headerStyle: { backgroundColor: 'transparent' },
+      headerStyle: {
+        // backgroundColor: isDarkMode ? darkMode.background : lightMode.background,
+        // // remove shadow
+        // elevation: 0,
+        // shadowOpacity: 0,
+        // borderBottomWidth: 0,
+      },
       headerRight: () => (
         <IconButton
           icon="information-outline"
@@ -261,11 +270,16 @@ export const StatsHomeScreen: FC<StatsHomeScreenProps> = ({ navigation }) => {
                 activeOpacity={0.7} // 0.2 default
               >
                 <CarouselCardHeaderText>{proj.projectName}</CarouselCardHeaderText>
-                <CarouselCardText># of thoughts: {proj.projectThoughts.length}</CarouselCardText>
-                {/* <CarouselCardText>created:</CarouselCardText>
-                <CarouselCardText>{DateHelper.parseOutTime(proj.createdDate)}</CarouselCardText> */}
-                <CarouselCardText>last updated:</CarouselCardText>
-                <CarouselCardText>{DateHelper.parseOutTime(proj.lastUpdatedDate)}</CarouselCardText>
+                <MaterialCommunityIcons
+                  name="account-circle"
+                  size={40}
+                  color={isDarkMode ? darkMode.primary : lightMode.primary}
+                  style={{ position: 'absolute', marginTop: 60 }}
+                />
+                <CarouselCardTextLastUpdateContainer>
+                  <CarouselCardText>last update:</CarouselCardText>
+                  <CarouselCardText>{DateHelper.parseOutTime(proj.lastUpdatedDate)}</CarouselCardText>
+                </CarouselCardTextLastUpdateContainer>
               </CarouselCard>
             ))}
           </CarouselContainer>
@@ -436,20 +450,6 @@ const HorizontalScrollView = styled.ScrollView`
   /* border: 1px solid green; */
 `;
 
-const CarouselContainer = styled.View`
-  flex-direction: row;
-  margin: 15px;
-`;
-
-const CarouselCard = styled.TouchableOpacity`
-  padding: 10px;
-  border-radius: 10px;
-  height: 160px;
-  width: 150px;
-  margin: 10px;
-  background-color: ${(props) => props.theme.dp1};
-`;
-
 const ChangeGraphRangeContainer = styled.View`
   justify-content: center;
   align-items: center;
@@ -459,25 +459,11 @@ const ChangeGraphRangeContainer = styled.View`
   margin: 0px;
 `;
 
-const CarouselCardHeaderText = styled.Text`
-  /* color: ${(props) => props.theme.primary}; */
-  margin-bottom: 5px;
-  color: ${(props) => props.theme.cardHeader};
-  font-size: 20px;
-`;
-
-const CarouselCardText = styled.Text`
-  /* text-align: center */
-  color: ${(props) => props.theme.textOnBackground};
-`;
-
 const SnackBarContainer = styled.View`
   /* border: 1px solid red; */
-  /* height: 60px; */
   position: absolute;
   width: 100%;
   z-index: 1;
-  /* bottom: 0; */
   top: 70px;
 `;
 
@@ -487,6 +473,42 @@ const GraphTitleContainer = styled.View`
 
 const GraphTitleText = styled.Text`
   font-size: 15px;
+  color: ${(props) => props.theme.textOnBackground};
+  text-align: center;
+`;
+
+const CarouselContainer = styled.View`
+  flex-direction: row;
+  margin: 15px;
+`;
+
+const CarouselCard = styled.TouchableOpacity`
+  align-items: center;
+  padding: 10px;
+  border-radius: 10px;
+  height: 160px;
+  width: 150px;
+  margin: 10px;
+  background-color: ${(props) => props.theme.dp1};
+`;
+
+const CarouselCardHeaderText = styled.Text`
+  margin-left: 0px;
+  margin-right: auto;
+  margin-bottom: 10px;
+  color: ${(props) => props.theme.cardHeader};
+  font-size: 20px;
+`;
+
+const CarouselCardTextLastUpdateContainer = styled.View`
+  position: absolute;
+  left: 0px;
+  right: 0px;
+  bottom: 12px;
+`;
+
+const CarouselCardText = styled.Text`
+  font-size: 13px;
   color: ${(props) => props.theme.textOnBackground};
   text-align: center;
 `;

--- a/thoughtbubble-mobile/src/components/StatsHomeScreen.tsx
+++ b/thoughtbubble-mobile/src/components/StatsHomeScreen.tsx
@@ -13,6 +13,8 @@ import { DateHelper } from '../utils/dateHelpers';
 import { StyleSheet } from 'react-native';
 import { Button, Snackbar } from 'react-native-paper';
 import { activityRangeMap } from '../constants/activityRanges';
+import { transformFileSync } from '@babel/core';
+import { timeStamp } from 'console';
 
 const { darkMode, lightMode } = colors;
 
@@ -59,11 +61,17 @@ export const StatsHomeScreen: FC<StatsHomeScreenProps> = ({ navigation }) => {
       <MainContainer>
         <SnackBarContainer>
           <Snackbar
-            style={styles.snackbar}
+            theme={{
+              colors: {
+                surface: isDarkMode ? darkMode.textOnSurface : lightMode.textOnSurface,
+              },
+            }}
+            style={{ backgroundColor: isDarkMode ? darkMode.dp1 : 'white' }}
             visible={snackbarVisable}
             onDismiss={() => setSnackbarVisable(false)}
+            duration={5000} // 7 default
             action={{
-              label: 'CLOSE',
+              label: 'close',
               onPress: () => setSnackbarVisable(false),
             }}
           >
@@ -241,10 +249,6 @@ const styles = StyleSheet.create({
     marginTop: 0,
     color: lightMode.primary,
   },
-  snackbar: {
-    zIndex: 100,
-    // marginTop: 300,
-  },
 });
 
 const ChangeGraphRangeContainer = styled.View`
@@ -276,5 +280,5 @@ const SnackBarContainer = styled.View`
   width: 100%;
   z-index: 1;
   /* bottom: 0; */
-  top: 60px;
+  top: 65px;
 `;

--- a/thoughtbubble-mobile/src/components/StatsProjectInfoScreen.tsx
+++ b/thoughtbubble-mobile/src/components/StatsProjectInfoScreen.tsx
@@ -7,6 +7,7 @@ import { RootState } from '../reducers/rootReducer';
 import { colors } from '../constants/colors';
 import { useDarkCheck } from '../hooks/useDarkCheck';
 import { locations } from '../constants/locations';
+import { DateHelper } from '../utils/dateHelpers';
 
 const { darkMode, lightMode } = colors;
 
@@ -43,6 +44,7 @@ export const StatsProjectInfoScreen: FC<StatsProjectInfoScreenProps> = function 
 
   return (
     <ThemeProvider theme={theme}>
+      {DateHelper.getDayNumber('2021-05-04T21:34:08.689Z')}
       <MainContainer>
         <PieChartHeader>where you spend your time</PieChartHeader>
         <VictoryPie

--- a/thoughtbubble-mobile/src/components/StatsProjectInfoScreen.tsx
+++ b/thoughtbubble-mobile/src/components/StatsProjectInfoScreen.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 import { useSelector } from 'react-redux';
-import { VictoryPie } from 'victory-native';
+import { VictoryAxis, VictoryBar, VictoryChart, VictoryLabel, VictoryPie, VictoryTheme } from 'victory-native';
 import styled, { ThemeProvider } from 'styled-components/native';
 import { StatsProjectInfoScreenProps } from '../interfaces/componentProps';
 import { RootState } from '../reducers/rootReducer';
@@ -8,7 +8,7 @@ import { colors } from '../constants/colors';
 import { useDarkCheck } from '../hooks/useDarkCheck';
 import { locations } from '../constants/locations';
 import { DateHelper } from '../utils/dateHelpers';
-import { Text } from 'react-native';
+import { Activity } from '../interfaces/data';
 
 const { darkMode, lightMode } = colors;
 
@@ -17,6 +17,8 @@ export const StatsProjectInfoScreen: FC<StatsProjectInfoScreenProps> = function 
   const isDarkMode = useDarkCheck();
   const userProjectsData = useSelector((state: RootState) => state.userProjectData);
   const project = userProjectsData.find((proj) => proj.id === projectId);
+  const userActivityData: Activity = useSelector((state: RootState) => state.activity);
+  // const projectGraphData = userActivityData; // WIP
 
   const theme = {
     // for styled-components ThemeProvider
@@ -45,10 +47,60 @@ export const StatsProjectInfoScreen: FC<StatsProjectInfoScreenProps> = function 
     { x: 'mobile', y: count.mobile },
   ];
 
+  const gridlessGraphTheme = VictoryTheme.material;
+  // remove colored grid
+  gridlessGraphTheme.axis.style.grid.stroke = isDarkMode ? '#FFFFFF15' : '#00000015';
+
   return (
     <ThemeProvider theme={theme}>
       <MainContainer>
-        <PieChartHeader>where you spend your time</PieChartHeader>
+        <GraphContainer>
+          <VictoryChart
+            theme={gridlessGraphTheme}
+            domainPadding={{ x: 25 }}
+            width={450}
+            padding={{ top: 10, bottom: 50, left: 55, right: 30 }} // 50 is default
+            height={300}
+          >
+            <VictoryAxis
+              // y-axis
+              dependentAxis
+            />
+            <VictoryAxis
+              // x-axis
+              tickFormat={() => ''}
+              offsetY={50}
+              axisLabelComponent={<VictoryLabel dy={16} />}
+              // label={generateXaxisLabel()}
+            />
+            <VictoryBar
+              // events={[
+              //   {
+              //     target: 'data',
+              //     eventHandlers: {
+              //       onPress: (_, clickedProps) => {
+              //         const activityDate = DateHelper.dayNToDate(clickedProps.datum.x);
+              //         const formatActivityDate = DateHelper.parseOutTime(activityDate.toISOString());
+              //         setSnackbarText(formatActivityDate);
+              //         setSnackbarVisable(true);
+              //         return null; // api expects a return
+              //       },
+              //     },
+              //   },
+              // ]}
+              style={{ data: { fill: isDarkMode ? darkMode.primary : lightMode.secondary } }}
+              data={userActivityData.graphData.slice(-1 * 7)}
+              height={300}
+              cornerRadius={{ topLeft: 2, topRight: 2 }}
+              animate={{
+                duration: 500,
+                onLoad: { duration: 250 },
+              }}
+              barRatio={0.8}
+            />
+          </VictoryChart>
+        </GraphContainer>
+        <PieChartTitle>where you spend your time</PieChartTitle>
         <VictoryPie
           data={pieChartData}
           style={{
@@ -61,7 +113,7 @@ export const StatsProjectInfoScreen: FC<StatsProjectInfoScreenProps> = function 
           height={350}
           colorScale={'heatmap'}
         />
-        <Text>{DateHelper.parseOutTime(project.createdDate)}</Text>
+        <CreatedDateText>project created on: {DateHelper.parseOutTime(project.createdDate)}</CreatedDateText>
       </MainContainer>
     </ThemeProvider>
   );
@@ -72,6 +124,15 @@ const MainContainer = styled.View`
   background-color: ${(props) => props.theme.background};
 `;
 
-const PieChartHeader = styled.Text`
+const GraphContainer = styled.View`
+  align-items: center;
+  justify-content: center;
+`;
+
+const PieChartTitle = styled.Text`
   color: ${(prop) => prop.theme.textOnBackground};
+`;
+
+const CreatedDateText = styled.Text`
+  color: ${(props) => props.theme.textOnBackground};
 `;

--- a/thoughtbubble-mobile/src/components/StatsProjectInfoScreen.tsx
+++ b/thoughtbubble-mobile/src/components/StatsProjectInfoScreen.tsx
@@ -89,7 +89,7 @@ export const StatsProjectInfoScreen: FC<StatsProjectInfoScreenProps> = function 
               //   },
               // ]}
               style={{ data: { fill: isDarkMode ? darkMode.primary : lightMode.secondary } }}
-              data={userActivityData.graphData.slice(-1 * 7)}
+              data={userActivityData.graphDataPerProject[projectId].slice(-1 * 7)}
               height={300}
               cornerRadius={{ topLeft: 2, topRight: 2 }}
               animate={{

--- a/thoughtbubble-mobile/src/components/StatsProjectInfoScreen.tsx
+++ b/thoughtbubble-mobile/src/components/StatsProjectInfoScreen.tsx
@@ -50,7 +50,10 @@ export const StatsProjectInfoScreen: FC<StatsProjectInfoScreenProps> = function 
 
   useLayoutEffect(() => {
     // set screen title
-    navigation.setOptions({ title: userProjectsData.find((proj) => proj.id === projectId).projectName });
+    navigation.setOptions({
+      title: userProjectsData.find((proj) => proj.id === projectId).projectName,
+      // headerStyle: { backgroundColor: isDarkMode ? darkMode.background : lightMode.background },
+    });
   });
 
   useFocusEffect(

--- a/thoughtbubble-mobile/src/components/StatsProjectInfoScreen.tsx
+++ b/thoughtbubble-mobile/src/components/StatsProjectInfoScreen.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback } from 'react';
+import React, { FC, useCallback, useLayoutEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { VictoryAxis, VictoryBar, VictoryChart, VictoryLabel, VictoryPie, VictoryTheme } from 'victory-native';
 import styled, { ThemeProvider } from 'styled-components/native';
@@ -22,8 +22,14 @@ export const StatsProjectInfoScreen: FC<StatsProjectInfoScreenProps> = function 
   const project = userProjectsData.find((proj) => proj.id === projectId);
   const userActivityData: Activity = useSelector((state: RootState) => state.activity);
 
+  useLayoutEffect(() => {
+    // set screen title
+    navigation.setOptions({ title: userProjectsData.find((proj) => proj.id === projectId).projectName });
+  });
+
   useFocusEffect(
     useCallback(() => {
+      // allow for dynamic reload of graph data
       dispatch(fetchActivityDataAction());
     }, []),
   );
@@ -40,7 +46,7 @@ export const StatsProjectInfoScreen: FC<StatsProjectInfoScreenProps> = function 
 
   // tally up the number of thoughts added via vscode and mobile
   const count = userProjectsData
-    .find((i) => i.id === projectId)
+    .find((proj) => proj.id === projectId)
     .projectThoughts.reduce(
       (acc, curr) => {
         if (curr.creationLocation === locations.MOBILE) acc.mobile += 1;

--- a/thoughtbubble-mobile/src/components/StatsProjectInfoScreen.tsx
+++ b/thoughtbubble-mobile/src/components/StatsProjectInfoScreen.tsx
@@ -18,8 +18,17 @@ import { StyleSheet } from 'react-native';
 const { darkMode, lightMode } = colors;
 
 export const StatsProjectInfoScreen: FC<StatsProjectInfoScreenProps> = function ({ route, navigation }) {
-  const { projectId } = route.params;
   const isDarkMode = useDarkCheck();
+  const theme = {
+    // for styled-components ThemeProvider
+    background: isDarkMode ? darkMode.background : lightMode.background,
+    primary: isDarkMode ? darkMode.primary : lightMode.primary,
+    primaryVariant: isDarkMode ? darkMode.primaryVariant : lightMode.primaryVariant,
+    secondary: isDarkMode ? darkMode.secondary : lightMode.secondary,
+    textOnBackground: isDarkMode ? darkMode.textOnBackground : lightMode.textOnBackground,
+    dp1: isDarkMode ? darkMode.dp1 : lightMode.background,
+  };
+  const { projectId } = route.params;
   const dispatch = useDispatch();
   const userProjectsData = useSelector((state: RootState) => state.userProjectData);
   const project = userProjectsData.find((proj) => proj.id === projectId);
@@ -50,16 +59,6 @@ export const StatsProjectInfoScreen: FC<StatsProjectInfoScreenProps> = function 
       dispatch(fetchActivityDataAction());
     }, []),
   );
-
-  const theme = {
-    // for styled-components ThemeProvider
-    background: isDarkMode ? darkMode.background : lightMode.background,
-    primary: isDarkMode ? darkMode.primary : lightMode.primary,
-    primaryVariant: isDarkMode ? darkMode.primaryVariant : lightMode.primaryVariant,
-    secondary: isDarkMode ? darkMode.secondary : lightMode.secondary,
-    textOnBackground: isDarkMode ? darkMode.textOnBackground : lightMode.textOnBackground,
-    dp1: isDarkMode ? darkMode.dp1 : lightMode.background,
-  };
 
   // tally up the number of thoughts added via vscode and mobile
   const count = userProjectsData
@@ -120,7 +119,7 @@ export const StatsProjectInfoScreen: FC<StatsProjectInfoScreenProps> = function 
               tickFormat={() => ''}
               offsetY={50}
               axisLabelComponent={<VictoryLabel dy={16} />}
-              // label={generateXaxisLabel()}
+              label={DateHelper.generateXaxisDateLabel(userActivityData.graphData, currRange)}
             />
             <VictoryBar
               // events={[

--- a/thoughtbubble-mobile/src/components/StatsProjectInfoScreen.tsx
+++ b/thoughtbubble-mobile/src/components/StatsProjectInfoScreen.tsx
@@ -1,5 +1,5 @@
-import React, { FC } from 'react';
-import { useSelector } from 'react-redux';
+import React, { FC, useCallback } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import { VictoryAxis, VictoryBar, VictoryChart, VictoryLabel, VictoryPie, VictoryTheme } from 'victory-native';
 import styled, { ThemeProvider } from 'styled-components/native';
 import { StatsProjectInfoScreenProps } from '../interfaces/componentProps';
@@ -9,16 +9,24 @@ import { useDarkCheck } from '../hooks/useDarkCheck';
 import { locations } from '../constants/locations';
 import { DateHelper } from '../utils/dateHelpers';
 import { Activity } from '../interfaces/data';
+import { useFocusEffect } from '@react-navigation/native';
+import { fetchActivityDataAction } from '../actions/fetchActivityAction';
 
 const { darkMode, lightMode } = colors;
 
 export const StatsProjectInfoScreen: FC<StatsProjectInfoScreenProps> = function ({ route, navigation }) {
   const { projectId } = route.params;
   const isDarkMode = useDarkCheck();
+  const dispatch = useDispatch();
   const userProjectsData = useSelector((state: RootState) => state.userProjectData);
   const project = userProjectsData.find((proj) => proj.id === projectId);
   const userActivityData: Activity = useSelector((state: RootState) => state.activity);
-  // const projectGraphData = userActivityData; // WIP
+
+  useFocusEffect(
+    useCallback(() => {
+      dispatch(fetchActivityDataAction());
+    }, []),
+  );
 
   const theme = {
     // for styled-components ThemeProvider

--- a/thoughtbubble-mobile/src/components/StatsProjectInfoScreen.tsx
+++ b/thoughtbubble-mobile/src/components/StatsProjectInfoScreen.tsx
@@ -8,13 +8,16 @@ import { colors } from '../constants/colors';
 import { useDarkCheck } from '../hooks/useDarkCheck';
 import { locations } from '../constants/locations';
 import { DateHelper } from '../utils/dateHelpers';
-import { Snackbar } from 'react-native-paper';
+import { Text } from 'react-native';
 
 const { darkMode, lightMode } = colors;
 
 export const StatsProjectInfoScreen: FC<StatsProjectInfoScreenProps> = function ({ route, navigation }) {
   const { projectId } = route.params;
   const isDarkMode = useDarkCheck();
+  const userProjectsData = useSelector((state: RootState) => state.userProjectData);
+  const project = userProjectsData.find((proj) => proj.id === projectId);
+
   const theme = {
     // for styled-components ThemeProvider
     background: isDarkMode ? darkMode.background : lightMode.background,
@@ -24,7 +27,6 @@ export const StatsProjectInfoScreen: FC<StatsProjectInfoScreenProps> = function 
     textOnBackground: isDarkMode ? darkMode.textOnBackground : lightMode.textOnBackground,
     dp1: isDarkMode ? darkMode.dp1 : lightMode.background,
   };
-  const userProjectsData = useSelector((state: RootState) => state.userProjectData);
 
   // tally up the number of thoughts added via vscode and mobile
   const count = userProjectsData
@@ -45,19 +47,6 @@ export const StatsProjectInfoScreen: FC<StatsProjectInfoScreenProps> = function 
 
   return (
     <ThemeProvider theme={theme}>
-      <Snackbar
-        // style={styles.snackbar}
-        visible={true}
-        onDismiss={() => console.log('snackbar dismiss')}
-        action={{
-          label: 'Undo',
-          onPress: () => {
-            // Do something
-          },
-        }}
-      >
-        Hey there! I'm a Snackbar.
-      </Snackbar>
       <MainContainer>
         <PieChartHeader>where you spend your time</PieChartHeader>
         <VictoryPie
@@ -72,6 +61,7 @@ export const StatsProjectInfoScreen: FC<StatsProjectInfoScreenProps> = function 
           height={350}
           colorScale={'heatmap'}
         />
+        <Text>{DateHelper.parseOutTime(project.createdDate)}</Text>
       </MainContainer>
     </ThemeProvider>
   );

--- a/thoughtbubble-mobile/src/components/StatsProjectInfoScreen.tsx
+++ b/thoughtbubble-mobile/src/components/StatsProjectInfoScreen.tsx
@@ -8,6 +8,7 @@ import { colors } from '../constants/colors';
 import { useDarkCheck } from '../hooks/useDarkCheck';
 import { locations } from '../constants/locations';
 import { DateHelper } from '../utils/dateHelpers';
+import { Snackbar } from 'react-native-paper';
 
 const { darkMode, lightMode } = colors;
 
@@ -44,7 +45,19 @@ export const StatsProjectInfoScreen: FC<StatsProjectInfoScreenProps> = function 
 
   return (
     <ThemeProvider theme={theme}>
-      {DateHelper.getDayNumber('2021-05-04T21:34:08.689Z')}
+      <Snackbar
+        // style={styles.snackbar}
+        visible={true}
+        onDismiss={() => console.log('snackbar dismiss')}
+        action={{
+          label: 'Undo',
+          onPress: () => {
+            // Do something
+          },
+        }}
+      >
+        Hey there! I'm a Snackbar.
+      </Snackbar>
       <MainContainer>
         <PieChartHeader>where you spend your time</PieChartHeader>
         <VictoryPie

--- a/thoughtbubble-mobile/src/components/navigation/StatsStackNavigator.tsx
+++ b/thoughtbubble-mobile/src/components/navigation/StatsStackNavigator.tsx
@@ -20,8 +20,8 @@ export function StatsStackNavigator() {
   };
   return (
     <Stack.Navigator screenOptions={dynamicScreenOptions}>
-      <Stack.Screen name="StatsHome" component={StatsHomeScreen} />
-      <Stack.Screen name="StatsForProject" component={StatsProjectInfoScreen} />
+      <Stack.Screen name="Analytics" component={StatsHomeScreen} />
+      <Stack.Screen name="Project Analytics" component={StatsProjectInfoScreen} />
     </Stack.Navigator>
   );
 }

--- a/thoughtbubble-mobile/src/constants/activityRanges.ts
+++ b/thoughtbubble-mobile/src/constants/activityRanges.ts
@@ -1,0 +1,17 @@
+import { ActivityRanges } from '../interfaces/stringLiteralTypes';
+
+export enum activityRanges {
+  '1W' = '1W',
+  '1M' = '1M',
+  '3M' = '3M',
+  '6M' = '6M',
+  '1Y' = '1Y',
+}
+
+export const activityRangeMap = new Map<ActivityRanges, number>([
+  ['1W', 7],
+  ['1M', 30],
+  ['3M', 91],
+  ['6M', 183],
+  ['1Y', 365],
+]);

--- a/thoughtbubble-mobile/src/interfaces/componentProps.ts
+++ b/thoughtbubble-mobile/src/interfaces/componentProps.ts
@@ -44,10 +44,10 @@ export interface ThoughtScreenProps {
 
 // for stats nav stack
 export interface StatsHomeScreenProps {
-  navigation: StackNavigationProp<StatsStackParamList, 'StatsHome'>;
+  navigation: StackNavigationProp<StatsStackParamList, 'Analytics'>;
 }
 
 export interface StatsProjectInfoScreenProps {
-  route: RouteProp<StatsStackParamList, 'StatsForProject'>;
-  navigation: StackNavigationProp<StatsStackParamList, 'StatsHome'>;
+  route: RouteProp<StatsStackParamList, 'Project Analytics'>;
+  navigation: StackNavigationProp<StatsStackParamList, 'Analytics'>;
 }

--- a/thoughtbubble-mobile/src/interfaces/data.ts
+++ b/thoughtbubble-mobile/src/interfaces/data.ts
@@ -25,3 +25,13 @@ export interface ProjectShape {
   completed: boolean;
   key?: string; // used later for -> https://github.com/jemise111/react-native-swipe-list-view#usage
 }
+
+export interface Activity {
+  data: Array<{
+    id: string;
+    activityDate: string; // Date string
+    userId?: string; // not showing up for now
+    projectId?: string; // not showing up for now
+  }>;
+  graphData: Array<{ x: number; y: number }>;
+}

--- a/thoughtbubble-mobile/src/interfaces/data.ts
+++ b/thoughtbubble-mobile/src/interfaces/data.ts
@@ -30,8 +30,9 @@ export interface Activity {
   data: Array<{
     id: string;
     activityDate: string; // Date string
-    userId?: string; // not showing up for now
+    userId: string; // not showing up for now
     projectId: string; // not showing up for now
   }>;
   graphData: Array<{ x: number; y: number }>; // data or all projects
+  graphDataPerProject: { [key: string]: Array<{ x: number; y: number }> };
 }

--- a/thoughtbubble-mobile/src/interfaces/data.ts
+++ b/thoughtbubble-mobile/src/interfaces/data.ts
@@ -31,7 +31,7 @@ export interface Activity {
     id: string;
     activityDate: string; // Date string
     userId?: string; // not showing up for now
-    projectId?: string; // not showing up for now
+    projectId: string; // not showing up for now
   }>;
-  graphData: Array<{ x: number; y: number }>;
+  graphData: Array<{ x: number; y: number }>; // data or all projects
 }

--- a/thoughtbubble-mobile/src/interfaces/navigation.ts
+++ b/thoughtbubble-mobile/src/interfaces/navigation.ts
@@ -14,8 +14,8 @@ export type ProjectStackParamList = {
 };
 
 export type StatsStackParamList = {
-  StatsHome: undefined;
-  StatsForProject: {
+  Analytics: undefined;
+  'Project Analytics': {
     projectId: string;
   };
 };

--- a/thoughtbubble-mobile/src/interfaces/stringLiteralTypes.ts
+++ b/thoughtbubble-mobile/src/interfaces/stringLiteralTypes.ts
@@ -1,2 +1,3 @@
 export type StatusFilters = 'all' | 'incomplete' | 'completed';
 export type Locations = 'mobile' | 'vscode';
+export type ActivityRanges = '1W' | '1M' | '3M' | '6M' | '1Y';

--- a/thoughtbubble-mobile/src/reducers/activityReducer.ts
+++ b/thoughtbubble-mobile/src/reducers/activityReducer.ts
@@ -5,6 +5,7 @@ import { Activity } from '../interfaces/data';
 const initialState = {
   data: [],
   graphData: [],
+  graphDataPerProject: {},
 };
 
 export const activityReducer = (state = initialState, action): Activity => {
@@ -57,33 +58,6 @@ export const activityReducer = (state = initialState, action): Activity => {
 
       return { ...state, data: payload, graphData, graphDataPerProject };
     }
-    // switch (type) {
-    //   case ActivityActionTypes.FETCH: {
-    //     // this case returns graph data in victory-native xy format
-    //     const todayNumb = DateHelper.getDayNumber(new Date().toISOString());
-    //     const map = new Map<number, number>();
-    //     // create map of all possible days
-    //     for (let i = 0; i <= todayNumb; i++) {
-    //       map.set(i, 0);
-    //     }
-    //     // loop over db data and populate map and populate graphDataPerProject keyfor let i
-    //     // const graphDataPerProject = {}; // HELP
-    //     for (let i = 0; i < payload.length; i++) {
-    //       const day = DateHelper.getDayNumber(payload[i].activityDate);
-    //       if (map.has(day)) {
-    //         map.set(day, map.get(day) + 1);
-    //       }
-    //       // add a key to graphDataPerProject for each unique projectId in the activity array
-    //       if (graphDataPerProject[payload[i].projectId]) continue;
-    //       else graphDataPerProject[payload[i]] = [];
-    //     }
-    //     // turn populated map into graph data
-    //     const graphData = [];
-    //     map.forEach((val, key) => {
-    //       graphData.push({ x: key, y: val });
-    //     });
-    //     return { ...state, data: payload, graphData, graphDataPerProject };
-    //   }
     default:
       return state;
   }

--- a/thoughtbubble-mobile/src/reducers/activityReducer.ts
+++ b/thoughtbubble-mobile/src/reducers/activityReducer.ts
@@ -11,27 +11,79 @@ export const activityReducer = (state = initialState, action): Activity => {
   const { type, payload } = action;
   switch (type) {
     case ActivityActionTypes.FETCH: {
-      // this case returns graph data in victory-native xy format
       const todayNumb = DateHelper.getDayNumber(new Date().toISOString());
-      const map = new Map<number, number>();
-      // create map of all possible days
+
+      // ==== for all projects combined ====
+      const graphDataMap = new Map<number, number>();
       for (let i = 0; i <= todayNumb; i++) {
-        map.set(i, 0);
+        graphDataMap.set(i, 0); // create map of all possible days
       }
-      // loop over db data and populate map
+      const graphData: Array<{ x: number; y: number }> = [];
+
+      // ==== split up by project ====
+      const graphDataPerProject = {};
+
+      // ==== populate activity maps ====
       for (let i = 0; i < payload.length; i++) {
+        const { projectId } = payload[i];
         const day = DateHelper.getDayNumber(payload[i].activityDate);
-        if (map.has(day)) {
-          map.set(day, map.get(day) + 1);
+        // handle map for all combined projects
+        graphDataMap.set(day, graphDataMap.get(day) + 1);
+        // handle individual project maps
+        if (!graphDataPerProject[projectId]) {
+          const map = new Map<number, number>();
+          for (let i = 0; i <= todayNumb; i++) {
+            map.set(i, 0);
+          }
+          graphDataPerProject[projectId] = map;
+        } else {
+          graphDataPerProject[projectId].set(day, graphDataPerProject[projectId].get(day) + 1);
         }
       }
-      // turn populated map into graph data
-      const graphData = [];
-      map.forEach((val, key) => {
+
+      // ==== turn populated maps into graph data ====
+      // for combined projects
+      graphDataMap.forEach((val, key) => {
         graphData.push({ x: key, y: val });
       });
-      return { ...state, graphData, data: payload };
+      // for individual projects
+      for (let k in graphDataPerProject) {
+        const projGraphData = []; // for curr proj
+        graphDataPerProject[k].forEach((val, key) => {
+          projGraphData.push({ x: key, y: val });
+        });
+        graphDataPerProject[k] = projGraphData;
+      }
+
+      return { ...state, data: payload, graphData, graphDataPerProject };
     }
+    // switch (type) {
+    //   case ActivityActionTypes.FETCH: {
+    //     // this case returns graph data in victory-native xy format
+    //     const todayNumb = DateHelper.getDayNumber(new Date().toISOString());
+    //     const map = new Map<number, number>();
+    //     // create map of all possible days
+    //     for (let i = 0; i <= todayNumb; i++) {
+    //       map.set(i, 0);
+    //     }
+    //     // loop over db data and populate map and populate graphDataPerProject keyfor let i
+    //     // const graphDataPerProject = {}; // HELP
+    //     for (let i = 0; i < payload.length; i++) {
+    //       const day = DateHelper.getDayNumber(payload[i].activityDate);
+    //       if (map.has(day)) {
+    //         map.set(day, map.get(day) + 1);
+    //       }
+    //       // add a key to graphDataPerProject for each unique projectId in the activity array
+    //       if (graphDataPerProject[payload[i].projectId]) continue;
+    //       else graphDataPerProject[payload[i]] = [];
+    //     }
+    //     // turn populated map into graph data
+    //     const graphData = [];
+    //     map.forEach((val, key) => {
+    //       graphData.push({ x: key, y: val });
+    //     });
+    //     return { ...state, data: payload, graphData, graphDataPerProject };
+    //   }
     default:
       return state;
   }

--- a/thoughtbubble-mobile/src/reducers/activityReducer.ts
+++ b/thoughtbubble-mobile/src/reducers/activityReducer.ts
@@ -1,22 +1,59 @@
 import { ActivityActionTypes } from '../constants/actionTypes';
+import { DateHelper } from '../utils/dateHelpers';
 
-const initialState = [];
+// const initialState = [];
+
+const initialState = {
+  data: [],
+  graphData: [],
+};
 
 interface Activity {
-  id: string;
-  activityDate: string; // Date string
-  userId: string;
-  projectId: string;
+  data: Array<{
+    id: string;
+    activityDate: string; // Date string
+    userId?: string; // not showing up for now
+    projectId?: string; // not showing up for now
+  }>;
+  graphData: Array<{ x: number; y: number }>;
 }
+
+// interface Activity {
+//   id: string;
+//   activityDate: string; // Date string
+//   userId: string;
+//   projectId: string;
+// }
 
 // enum activityActionTypes {
 // 	FETCH = 'activity/fetch',
 // }
 
-export const activityReducer = (state = initialState, action): Activity[] => {
-  switch (action.type) {
-    case ActivityActionTypes.FETCH:
-      return action.payload;
+export const activityReducer = (state = initialState, action): Activity => {
+  const { type, payload } = action;
+  switch (type) {
+    case ActivityActionTypes.FETCH: {
+      // this case returns graph data in victory-native xy format
+      const todayNumb = DateHelper.getDayNumber(new Date().toISOString());
+      const map = new Map<number, number>();
+      // create map of all possible days
+      for (let i = 0; i <= todayNumb; i++) {
+        map.set(i, 0);
+      }
+      // loop over db data and populate map
+      for (let i = 0; i < payload.length; i++) {
+        const day = DateHelper.getDayNumber(payload[i].activityDate);
+        if (map.has(day)) {
+          map.set(day, map.get(day) + 1);
+        }
+      }
+      // turn populated map into graph data
+      const graphData = [];
+      map.forEach((val, key) => {
+        graphData.push({ x: key, y: val });
+      });
+      return { ...state, graphData, data: payload };
+    }
     default:
       return state;
   }

--- a/thoughtbubble-mobile/src/reducers/activityReducer.ts
+++ b/thoughtbubble-mobile/src/reducers/activityReducer.ts
@@ -1,33 +1,11 @@
 import { ActivityActionTypes } from '../constants/actionTypes';
 import { DateHelper } from '../utils/dateHelpers';
-
-// const initialState = [];
+import { Activity } from '../interfaces/data';
 
 const initialState = {
   data: [],
   graphData: [],
 };
-
-interface Activity {
-  data: Array<{
-    id: string;
-    activityDate: string; // Date string
-    userId?: string; // not showing up for now
-    projectId?: string; // not showing up for now
-  }>;
-  graphData: Array<{ x: number; y: number }>;
-}
-
-// interface Activity {
-//   id: string;
-//   activityDate: string; // Date string
-//   userId: string;
-//   projectId: string;
-// }
-
-// enum activityActionTypes {
-// 	FETCH = 'activity/fetch',
-// }
 
 export const activityReducer = (state = initialState, action): Activity => {
   const { type, payload } = action;

--- a/thoughtbubble-mobile/src/utils/dateHelpers.ts
+++ b/thoughtbubble-mobile/src/utils/dateHelpers.ts
@@ -39,13 +39,6 @@ export class DateHelper {
   static getLastNDayNumbers(range: ActivityRanges): Map<number, number> {
     const currentIso = new Date().toISOString();
     let currentDayNumb = this.getDayNumber(currentIso);
-    // const activityRangeMap = new Map([
-    //   ['1W', 7],
-    //   ['1M', 30],
-    //   ['3M', 91],
-    //   ['6M', 183],
-    //   ['1Y', 365],
-    // ]);
     const N = activityRangeMap.get(range);
     const map = new Map<number, number>();
     for (let i = 0; i < N; i++) map.set(currentDayNumb--, 0);
@@ -62,11 +55,12 @@ export class DateHelper {
   }
 
   /**
-   * given day # from start date 4/1/2021, return `mm/dd` format
-   * @param day
-   * @returns
+   * @param day # from start date 4/1/2021
+   * @returns date object of the date #
    */
-  static dayToMMDD(day: string): string {
-    return '';
+  static dayNToDate(dayN: number): Date {
+    const result = new Date(2021, 3, 1);
+    result.setDate(result.getDate() + dayN);
+    return result;
   }
 }

--- a/thoughtbubble-mobile/src/utils/dateHelpers.ts
+++ b/thoughtbubble-mobile/src/utils/dateHelpers.ts
@@ -5,18 +5,6 @@ import { ActivityRanges } from '../interfaces/stringLiteralTypes';
  * Methods for dealing with dates. Predominantly used in stats screen.
  */
 export class DateHelper {
-  // private static activityRangeMap: Map<string, number>;
-
-  // constructor(public activityRangeMap) {
-  //   this.activityRangeMap = new Map([
-  //     ['1W', 7],
-  //     ['1M', 30],
-  //     ['3M', 91],
-  //     ['6M', 183],
-  //     ['1Y', 365],
-  //   ]);
-  // }
-
   /**
    * given a date in iso format, calculate days from app start date 4/1/2021
    * @param date from db in iso format `2021-05-04T21:34:08.689Z`
@@ -70,5 +58,18 @@ export class DateHelper {
     let month = (1 + date.getMonth()).toString().padStart(2, '0');
     let day = date.getDate().toString().padStart(2, '0');
     return month + '/' + day + '/' + year;
+  }
+
+  /**
+   * given array of x, y coords generate x label of the form "mm/dd/yyyy -> mm/dd/yyyy"
+   * @param graphData xy, pairs for victorychart
+   * @param currRange 7, 30, 91 etc...
+   * @returns "mm/dd/yyyy -> mm/dd/yyyy"
+   */
+  static generateXaxisDateLabel(graphData: Array<{ x: number; y: number }>, currRange: number): string {
+    const xys = graphData.slice(-1 * currRange);
+    const first = this.dateToMMDDYYY(this.dayNToDate(xys[0].x));
+    const last = this.dateToMMDDYYY(this.dayNToDate(xys[xys.length - 1].x));
+    return `${first}  →  ${last}`;
   }
 }

--- a/thoughtbubble-mobile/src/utils/dateHelpers.ts
+++ b/thoughtbubble-mobile/src/utils/dateHelpers.ts
@@ -63,4 +63,12 @@ export class DateHelper {
     result.setDate(result.getDate() + dayN);
     return result;
   }
+
+  static dateToMMDDYYY(date: Date): string {
+    // from SO
+    let year = date.getFullYear();
+    let month = (1 + date.getMonth()).toString().padStart(2, '0');
+    let day = date.getDate().toString().padStart(2, '0');
+    return month + '/' + day + '/' + year;
+  }
 }

--- a/thoughtbubble-mobile/src/utils/dateHelpers.ts
+++ b/thoughtbubble-mobile/src/utils/dateHelpers.ts
@@ -1,51 +1,71 @@
+export type activityRanges = '1W' | '1M' | '3M' | '6M' | '1Y';
+
 /**
  * Methods for dealing with dates. Predominantly used in stats screen.
  */
 export class DateHelper {
-  constructor() {}
+  // private static activityRangeMap: Map<string, number>;
+
+  // constructor(public activityRangeMap) {
+  //   this.activityRangeMap = new Map([
+  //     ['1W', 7],
+  //     ['1M', 30],
+  //     ['3M', 91],
+  //     ['6M', 183],
+  //     ['1Y', 365],
+  //   ]);
+  // }
 
   /**
-   * given a date, return which # out of 365(6) it is
+   * given a date in iso format, calculate days from app start date 4/1/2021
    * @param date from db in iso format `2021-05-04T21:34:08.689Z`
+   * @returns date number
    */
-  static getDayOutOf365 = function (isoDate: string): number {
+  static getDayNumber(isoDate: string): number {
     const date = new Date(isoDate);
-    console.log(date.getFullYear());
-    const start = new Date(date.getFullYear(), 0, 0);
+    const start = new Date(2021, 3, 1);
     const diff = (date as any) - (start as any);
     const oneDay = 1000 * 60 * 60 * 24;
     const dayN = Math.floor(diff / oneDay);
-    console.log('Day of year: ' + dayN);
+    // console.log('Day of tB: ' + dayN);
     return dayN;
-  };
+  }
 
   /**
-   *
+   * create map which is used to create activity per day iterable
    * @returns a map contained the day #s out of 365 for the last week
    */
-  static getLast7DaysOutOf365 = function (): Map<number, number> {
+  static getLastNDayNumbers(range: activityRanges): Map<number, number> {
     const currentIso = new Date().toISOString();
-    let currentDayNumb = this.getDayOutOf365(currentIso);
+    let currentDayNumb = this.getDayNumber(currentIso);
+    const activityRangeMap = new Map([
+      ['1W', 7],
+      ['1M', 30],
+      ['3M', 91],
+      ['6M', 183],
+      ['1Y', 365],
+    ]);
+    const N = activityRangeMap.get(range);
     const map = new Map<number, number>();
-    for (let i = 0; i < 7; i++) map.set(currentDayNumb--, 0);
+    for (let i = 0; i < N; i++) map.set(currentDayNumb--, 0);
     return map;
-  };
+  }
 
   /**
    * @param lastUpdatedDate from db in iso format `2021-05-04T21:34:08.689Z`
    * @returns of the form `Mon Apr 12, 2021`
    */
-  static parseOutTime = function (lastUpdatedDate: string): string {
+  static parseOutTime(lastUpdatedDate: string): string {
     const dateTime = new Date(lastUpdatedDate).toString().split(' ');
     return dateTime.slice(0, 3).join(' ') + `, ${dateTime[3]}`;
-  };
+  }
 
   /**
-   * map day # to 365
+   * given day # from start date 4/1/2021, return `mm/dd` format
    * @param day
    * @returns
    */
-  static dayToMMDD = function (day: string): string {
+  static dayToMMDD(day: string): string {
     return '';
-  };
+  }
 }

--- a/thoughtbubble-mobile/src/utils/dateHelpers.ts
+++ b/thoughtbubble-mobile/src/utils/dateHelpers.ts
@@ -1,4 +1,5 @@
-export type activityRanges = '1W' | '1M' | '3M' | '6M' | '1Y';
+import { activityRangeMap } from '../constants/activityRanges';
+import { ActivityRanges } from '../interfaces/stringLiteralTypes';
 
 /**
  * Methods for dealing with dates. Predominantly used in stats screen.
@@ -35,16 +36,16 @@ export class DateHelper {
    * create map which is used to create activity per day iterable
    * @returns a map contained the day #s out of 365 for the last week
    */
-  static getLastNDayNumbers(range: activityRanges): Map<number, number> {
+  static getLastNDayNumbers(range: ActivityRanges): Map<number, number> {
     const currentIso = new Date().toISOString();
     let currentDayNumb = this.getDayNumber(currentIso);
-    const activityRangeMap = new Map([
-      ['1W', 7],
-      ['1M', 30],
-      ['3M', 91],
-      ['6M', 183],
-      ['1Y', 365],
-    ]);
+    // const activityRangeMap = new Map([
+    //   ['1W', 7],
+    //   ['1M', 30],
+    //   ['3M', 91],
+    //   ['6M', 183],
+    //   ['1Y', 365],
+    // ]);
     const N = activityRangeMap.get(range);
     const map = new Map<number, number>();
     for (let i = 0; i < N; i++) map.set(currentDayNumb--, 0);


### PR DESCRIPTION
- dynamic carousel card shadow
- activity graphs for all users projects combined as well as user's individual projects
- on combined graph, can press on data point to see a snackbar with the date (will change later)
- activity streak implemented
- info modal explains how activity is tracked and links to github repo
- started re-styling navigation headers, will continue on new branch + start on bottom nav tabs