### PR TITLE
order and sort projects

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  // "editor.minimap.enabled": false,
+  "editor.minimap.enabled": false,
   "editor.insertSpaces": false,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true

--- a/thoughtbubble-api/controllers/userInfoController.ts
+++ b/thoughtbubble-api/controllers/userInfoController.ts
@@ -81,7 +81,7 @@ class userInfoController {
         res.sendStatus(400);
       }
     }
-    await getConnection() //
+    await getConnection()
       .createQueryBuilder()
       .update(User)
       .set({ dailyEmail: !dailyEmailSetting })
@@ -126,6 +126,59 @@ class userInfoController {
       .where('githubId = :githubId', { githubId: userSub })
       .execute();
     res.sendStatus(200);
+  };
+
+  public updateProjectOrder = async (req: Request, res: Response) => {
+    const { userSub, projectOrder } = req.body;
+    const user = await User.findOne({ githubId: userSub });
+    try {
+      await getConnection()
+        .createQueryBuilder()
+        .update(User)
+        .set({ projectOrder: projectOrder })
+        .where('githubId = :githubId', { githubId: userSub })
+        .execute();
+      res.sendStatus(200);
+    } catch (err) {
+      console.error(this.location, err);
+      res.sendStatus(400);
+    }
+  };
+
+  public updateProjectDirection = async (req: Request, res: Response) => {
+    const { userSub, projectDirection } = req.body;
+    const user = await User.findOne({ githubId: userSub });
+    try {
+      await getConnection()
+        .createQueryBuilder()
+        .update(User)
+        .set({ projectDirection: projectDirection })
+        .where('githubId = :githubId', { githubId: userSub })
+        .execute();
+      res.sendStatus(200);
+    } catch (err) {
+      console.error(this.location, err);
+      res.sendStatus(400);
+    }
+  };
+
+  public toggleProjectOrderSetting = async (req: Request, res: Response) => {
+    const { userSub, projectOrder, projectDirection } = req.body;
+    console.log(projectOrder, projectDirection);
+    const user = await User.findOne({ githubId: userSub });
+    const currSetting = user?.saveOrder;
+    try {
+      await getConnection()
+        .createQueryBuilder()
+        .update(User)
+        .set({ saveOrder: !currSetting, projectOrder, projectDirection })
+        .where('githubId = :githubId', { githubId: userSub })
+        .execute();
+      res.sendStatus(200);
+    } catch (err) {
+      console.error(this.location, err);
+      res.sendStatus(400);
+    }
   };
 }
 

--- a/thoughtbubble-api/controllers/userInfoController.ts
+++ b/thoughtbubble-api/controllers/userInfoController.ts
@@ -26,6 +26,7 @@ class userInfoController {
         darkMode: user?.darkMode,
         projectOrder: user?.projectOrder,
         projectDirection: user?.projectDirection,
+        saveOrder: user?.saveOrder,
       };
       res.send(userInfo);
     } catch (err) {

--- a/thoughtbubble-api/controllers/userInfoController.ts
+++ b/thoughtbubble-api/controllers/userInfoController.ts
@@ -15,7 +15,7 @@ class userInfoController {
     const userSub = req.query.userSub as string;
     try {
       const user = await User.findOne({ githubId: userSub });
-      // return user item without projects, cannot just delete projs cause of ts2790
+      // return user obj without projects arr, cannot just delete projs arr cause of ts2790
       const userInfo = {
         id: user?.id,
         username: user?.username,
@@ -24,6 +24,8 @@ class userInfoController {
         dailyEmail: user?.dailyEmail,
         weeklyEmail: user?.weeklyEmail,
         darkMode: user?.darkMode,
+        projectOrder: user?.projectOrder,
+        projectDirection: user?.projectDirection,
       };
       res.send(userInfo);
     } catch (err) {

--- a/thoughtbubble-api/entities/User.ts
+++ b/thoughtbubble-api/entities/User.ts
@@ -1,6 +1,20 @@
 import { Entity, PrimaryGeneratedColumn, Column, BaseEntity, OneToMany, JoinColumn } from 'typeorm';
+import { WatchDirectoryKind } from 'typescript';
 import { Activity } from './Activity';
 import { Project } from './Project';
+
+export type Direction = 'asc' | 'desc';
+export type OrderType = 'lastUpdated' | 'size' | 'alphabetical';
+
+export enum Directions {
+  ASC = 'asc',
+  DESC = 'desc',
+}
+export enum OrderTypes {
+  LAST_UPDATED = 'lastUpdated',
+  ALPHABETICAL = 'alphabetical',
+  SIZE = 'size',
+}
 
 @Entity()
 export class User extends BaseEntity {
@@ -20,6 +34,14 @@ export class User extends BaseEntity {
 
   @Column('boolean', { default: true })
   darkMode!: boolean;
+
+  // the order the user wants their projects displayed on main projects screen
+  @Column('text', { default: OrderTypes.LAST_UPDATED })
+  projectOrder!: OrderType;
+
+  // the direction the user wants their projects displayed on main projects screen
+  @Column('text', { default: Directions.DESC })
+  projectDirection!: Direction;
 
   @Column('text', { unique: true })
   githubId!: string;

--- a/thoughtbubble-api/entities/User.ts
+++ b/thoughtbubble-api/entities/User.ts
@@ -43,6 +43,10 @@ export class User extends BaseEntity {
   @Column('text', { default: Directions.DESC })
   projectDirection!: Direction;
 
+  // whether or not the user want to save the order for their next session
+  @Column('boolean', { default: false })
+  saveOrder!: boolean;
+
   @Column('text', { unique: true })
   githubId!: string;
 

--- a/thoughtbubble-api/routes/userInfo.ts
+++ b/thoughtbubble-api/routes/userInfo.ts
@@ -1,22 +1,34 @@
 import express from 'express';
-import ProjectsController from '../controllers/userInfoController';
+import UserInfoController from '../controllers/userInfoController';
 
 const router = express.Router();
 
 router // api/userinfo
   .route('/')
-  .get(ProjectsController.fetchUserInfo);
+  .get(UserInfoController.fetchUserInfo);
 
 router // api/userinfo/email
   .route('/dailyemail')
-  .put(ProjectsController.toggleDailyEmailSetting);
+  .put(UserInfoController.toggleDailyEmailSetting);
 
 router // api/userinfo/email
   .route('/weeklyemail')
-  .put(ProjectsController.toggleWeeklyEmailSetting);
+  .put(UserInfoController.toggleWeeklyEmailSetting);
 
 router // api/userinfo/email
   .route('/darkmode')
-  .put(ProjectsController.toggleDarkMode);
+  .put(UserInfoController.toggleDarkMode);
+
+router // api/userinfo/
+  .route('/projectOrder')
+  .put(UserInfoController.updateProjectOrder);
+
+router // api/userinfo/
+  .route('/projectDirection')
+  .put(UserInfoController.updateProjectDirection);
+
+router // api/userinfo/
+  .route('/saveOrder')
+  .put(UserInfoController.toggleProjectOrderSetting);
 
 export { router };

--- a/thoughtbubble-mobile/package-lock.json
+++ b/thoughtbubble-mobile/package-lock.json
@@ -29,7 +29,7 @@
         "react-native": "0.63.4",
         "react-native-auth0": "^2.7.0",
         "react-native-gesture-handler": "^1.10.0",
-        "react-native-paper": "^4.8.0",
+        "react-native-paper": "^4.9.1",
         "react-native-reanimated": "^1.13.2",
         "react-native-safe-area-context": "^3.1.9",
         "react-native-screens": "^2.17.1",
@@ -926,9 +926,9 @@
       "dev": true
     },
     "node_modules/@callstack/react-theme-provider": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@callstack/react-theme-provider/-/react-theme-provider-3.0.5.tgz",
-      "integrity": "sha512-Iec+ybWN0FvNj87sD3oWo/49edGUP0UOSdMnzCJEFJIDYr992ECIuOV89burAAh2/ibPCxgLiK6dmgv2mO/8Tg==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@callstack/react-theme-provider/-/react-theme-provider-3.0.6.tgz",
+      "integrity": "sha512-wwKMXfmklfogpalNZT0W+jh76BIquiYUiQHOaPmt/PCyCEP/E6rP+e7Uie6mBZrfkea9WJYJ+mus6r+45JAEhg==",
       "dependencies": {
         "deepmerge": "^3.2.0",
         "hoist-non-react-statics": "^3.3.0"
@@ -12778,11 +12778,11 @@
       "integrity": "sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg=="
     },
     "node_modules/react-native-paper": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/react-native-paper/-/react-native-paper-4.8.0.tgz",
-      "integrity": "sha512-XgMxcXHbawCZJFLfvXYH7V7i9HEsgjs2EidtVpP8j8aonUknQAMlI4wihgSxL6419U6iFDEaY2FDFRVAWuhucw==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/react-native-paper/-/react-native-paper-4.9.1.tgz",
+      "integrity": "sha512-vGgNvQE/GlNSjwJw+1LW0yoULTh7enxln16bYfOoI9Xiz1NOKxhfyQN0/LlZn7JFhRdbXW+3+6yMBJ50Emt+ng==",
       "dependencies": {
-        "@callstack/react-theme-provider": "^3.0.5",
+        "@callstack/react-theme-provider": "^3.0.6",
         "color": "^3.1.2",
         "react-native-iphone-x-helper": "^1.3.1"
       },
@@ -16525,9 +16525,9 @@
       "dev": true
     },
     "@callstack/react-theme-provider": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@callstack/react-theme-provider/-/react-theme-provider-3.0.5.tgz",
-      "integrity": "sha512-Iec+ybWN0FvNj87sD3oWo/49edGUP0UOSdMnzCJEFJIDYr992ECIuOV89burAAh2/ibPCxgLiK6dmgv2mO/8Tg==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@callstack/react-theme-provider/-/react-theme-provider-3.0.6.tgz",
+      "integrity": "sha512-wwKMXfmklfogpalNZT0W+jh76BIquiYUiQHOaPmt/PCyCEP/E6rP+e7Uie6mBZrfkea9WJYJ+mus6r+45JAEhg==",
       "requires": {
         "deepmerge": "^3.2.0",
         "hoist-non-react-statics": "^3.3.0"
@@ -26206,11 +26206,11 @@
       "integrity": "sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg=="
     },
     "react-native-paper": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/react-native-paper/-/react-native-paper-4.8.0.tgz",
-      "integrity": "sha512-XgMxcXHbawCZJFLfvXYH7V7i9HEsgjs2EidtVpP8j8aonUknQAMlI4wihgSxL6419U6iFDEaY2FDFRVAWuhucw==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/react-native-paper/-/react-native-paper-4.9.1.tgz",
+      "integrity": "sha512-vGgNvQE/GlNSjwJw+1LW0yoULTh7enxln16bYfOoI9Xiz1NOKxhfyQN0/LlZn7JFhRdbXW+3+6yMBJ50Emt+ng==",
       "requires": {
-        "@callstack/react-theme-provider": "^3.0.5",
+        "@callstack/react-theme-provider": "^3.0.6",
         "color": "^3.1.2",
         "react-native-iphone-x-helper": "^1.3.1"
       }

--- a/thoughtbubble-mobile/package.json
+++ b/thoughtbubble-mobile/package.json
@@ -31,7 +31,7 @@
     "react-native": "0.63.4",
     "react-native-auth0": "^2.7.0",
     "react-native-gesture-handler": "^1.10.0",
-    "react-native-paper": "^4.8.0",
+    "react-native-paper": "^4.9.1",
     "react-native-reanimated": "^1.13.2",
     "react-native-safe-area-context": "^3.1.9",
     "react-native-screens": "^2.17.1",

--- a/thoughtbubble-mobile/src/actions/userInfoActions.ts
+++ b/thoughtbubble-mobile/src/actions/userInfoActions.ts
@@ -1,4 +1,6 @@
 import axios from 'axios';
+import { UserInfoActionTypes } from '../constants/actionTypes';
+import { Direction, OrderType } from '../interfaces/stringLiteralTypes';
 
 export const fetchUserInfoAction = () => {
   return async (dispatch, getState) => {
@@ -51,6 +53,52 @@ export const changeDarkModeAction = () => {
       })
       .then(() => {
         dispatch({ type: 'toggleDarkMode', payload: '' });
+      })
+      .catch((err) => console.error('@userInfoActions.ts: ', err));
+  };
+};
+// ========
+export const changeProjectOrderAction = (projectOrder: OrderType) => {
+  return async (dispatch, getState) => {
+    const userSub = getState().storedUser.sub;
+    axios
+      .put('http://localhost:3001/api/userinfo/projectOrder', {
+        userSub,
+        projectOrder,
+      })
+      .then(() => {
+        dispatch({ type: UserInfoActionTypes.UPDATE_ORDER, payload: projectOrder });
+      })
+      .catch((err) => console.error('@userInfoActions.ts: ', err));
+  };
+};
+
+export const changeProjectDirectionAction = (projectDirection: Direction) => {
+  return async (dispatch, getState) => {
+    const userSub = getState().storedUser.sub;
+    axios
+      .put('http://localhost:3001/api/userinfo/projectDirection', {
+        userSub,
+        projectDirection,
+      })
+      .then(() => {
+        dispatch({ type: UserInfoActionTypes.UPDATE_DIRECTION, payload: projectDirection });
+      })
+      .catch((err) => console.error('@userInfoActions.ts: ', err));
+  };
+};
+
+export const changeSaveOrderSettingAction = (projectOrder: OrderType, projectDirection: Direction) => {
+  return async (dispatch, getState) => {
+    const userSub = getState().storedUser.sub;
+    axios
+      .put('http://localhost:3001/api/userinfo/saveOrder', {
+        userSub,
+        projectOrder,
+        projectDirection,
+      })
+      .then(() => {
+        dispatch({ type: UserInfoActionTypes.UPDATE_SAVE_SETTING });
       })
       .catch((err) => console.error('@userInfoActions.ts: ', err));
   };

--- a/thoughtbubble-mobile/src/components/ArchiveDeleteModal.tsx
+++ b/thoughtbubble-mobile/src/components/ArchiveDeleteModal.tsx
@@ -7,6 +7,7 @@ import { archiveProjectAction, deleteProjectAction } from '../actions/projectAct
 import { useDarkCheck } from '../hooks/useDarkCheck';
 import { colors } from '../constants/colors';
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
+import { Overlay } from './Overlay';
 
 interface ArchiveDeleteModalProps {
   modalVisible: boolean;
@@ -135,15 +136,15 @@ const ModalActionText = styled.Text`
   padding-left: 20px;
 `;
 
-const Overlay = styled.View`
-  position: absolute;
-  height: 1000px;
-  top: 0px;
-  right: 0px;
-  left: 0px;
-  background-color: #00000095;
-  z-index: 999999;
-`;
+// const Overlay = styled.View`
+//   position: absolute;
+//   height: 1000px;
+//   top: 0px;
+//   right: 0px;
+//   left: 0px;
+//   background-color: #00000095;
+//   z-index: 999999;
+// `;
 
 const InfoModalContainer = styled.View`
   height: 180px;

--- a/thoughtbubble-mobile/src/components/Overlay.tsx
+++ b/thoughtbubble-mobile/src/components/Overlay.tsx
@@ -1,0 +1,14 @@
+import styled from 'styled-components/native';
+
+/**
+ * grey/black overlay that covers entire screen, used with a bottom sheet modal
+ */
+export const Overlay = styled.View`
+  position: absolute;
+  height: 1000px;
+  top: 0px;
+  right: 0px;
+  left: 0px;
+  background-color: #00000095;
+  z-index: 999999;
+`;

--- a/thoughtbubble-mobile/src/components/ProjectDisplaySettingsModal.tsx
+++ b/thoughtbubble-mobile/src/components/ProjectDisplaySettingsModal.tsx
@@ -1,0 +1,209 @@
+import React, { FC, memo, useState } from 'react';
+import { Modal, StyleSheet } from 'react-native';
+import { IconButton, Switch, RadioButton } from 'react-native-paper';
+import styled from 'styled-components/native';
+import { colors } from '../constants/colors';
+import { useDarkCheck } from '../hooks/useDarkCheck';
+import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
+import { Overlay } from './Overlay';
+
+// const { darkMode, lightMode } = colors;
+
+type Order = 'asc' | 'desc';
+enum Orders {
+  ASC = 'asc',
+  DESC = 'desc',
+}
+
+interface ProjectDisplaySettingsModalProps {
+  modalVisible: boolean;
+  setModalVisible: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export const ProjectDisplaySettingsModal: FC<ProjectDisplaySettingsModalProps> = memo(function ({
+  modalVisible,
+  setModalVisible,
+}) {
+  const [checked, setChecked] = useState<Order>('asc');
+  const isDarkMode = useDarkCheck();
+  return (
+    <>
+      {modalVisible ? <Overlay /> : <></>}
+      <Modal visible={modalVisible} animationType="slide" transparent>
+        <InfoModalContainer>
+          <IconButton
+            icon="close"
+            color={isDarkMode ? colors.darkMode.secondary : colors.lightMode.secondary}
+            size={35}
+            onPress={() => setModalVisible(false)}
+            style={styles.modalCloseIconBtn}
+          />
+          <ModalTitle>project display options</ModalTitle>
+          <OrderOptionsContainer>
+            <OrderOptionItem>
+              <MaterialCommunityIcons
+                name="clock-outline"
+                size={35}
+                color={isDarkMode ? colors.darkMode.primary : colors.lightMode.primary}
+                style={styles.modalActionIcon}
+              />
+              <OrderOptionItemText>last updated (default)</OrderOptionItemText>
+            </OrderOptionItem>
+            <OrderOptionItem>
+              <MaterialCommunityIcons
+                name="sort-reverse-variant"
+                size={35}
+                color={isDarkMode ? colors.darkMode.primary : colors.lightMode.primary}
+                style={styles.modalActionIcon}
+              />
+              <OrderOptionItemText>by size</OrderOptionItemText>
+            </OrderOptionItem>
+            <OrderOptionItem>
+              <MaterialCommunityIcons
+                // name="sort-alphabetical-ascending-variant"
+                name="alphabetical-variant"
+                size={35}
+                color={isDarkMode ? colors.darkMode.primary : colors.lightMode.primary}
+                style={styles.modalActionIcon}
+              />
+              <OrderOptionItemText>alphabetical</OrderOptionItemText>
+            </OrderOptionItem>
+
+            <RadioButtonContainer>
+              <RadioButton.Group onValueChange={(checked) => setChecked(checked as Order)} value={checked}>
+                <RadioBtnItemContainer>
+                  <MaterialCommunityIcons
+                    name="chevron-up"
+                    size={35}
+                    color={isDarkMode ? colors.darkMode.primary : colors.lightMode.primary}
+                    style={styles.modalActionIcon}
+                  />
+                  <RadioButton.Item
+                    label="ascending"
+                    // position="leading"
+                    value="asc"
+                    uncheckedColor="grey"
+                    mode="android" // works on both os, I prefer android style
+                    style={styles.radioButtonItem}
+                  />
+                </RadioBtnItemContainer>
+                <RadioBtnItemContainer>
+                  <MaterialCommunityIcons
+                    name="chevron-down"
+                    size={35}
+                    color={isDarkMode ? colors.darkMode.primary : colors.lightMode.primary}
+                    style={styles.modalActionIcon}
+                  />
+                  <RadioButton.Item
+                    label="descending"
+                    // position="leading"
+                    value="desc"
+                    uncheckedColor="grey"
+                    mode="android" // works on both os, I prefer android style
+                    style={styles.radioButtonItem}
+                  />
+                </RadioBtnItemContainer>
+              </RadioButton.Group>
+            </RadioButtonContainer>
+            <SaveOrderContainer>
+              <MaterialCommunityIcons
+                name="cogs"
+                size={35}
+                // color={isDarkMode ? colors.darkMode.primary : colors.lightMode.primary}
+                color="#808080"
+                style={styles.modalActionIcon}
+              />
+              <SaveOrderText>save settings for next time?</SaveOrderText>
+              <Switch value={true} onValueChange={() => {}} style={styles.switch} />
+            </SaveOrderContainer>
+          </OrderOptionsContainer>
+        </InfoModalContainer>
+      </Modal>
+    </>
+  );
+});
+
+const InfoModalContainer = styled.View`
+  height: 450px;
+  background-color: ${(props) => props.theme.background};
+  margin-top: auto;
+  margin-bottom: 0px;
+  border-top-left-radius: 20px;
+  border-top-right-radius: 20px;
+`;
+
+const ModalTitle = styled.Text`
+  /* border: 1px solid red; */
+  color: grey;
+  width: 250px;
+  font-size: 20px;
+  margin: 10px;
+  margin-top: 20px;
+  margin-left: 20px;
+  margin-bottom: 30px;
+`;
+
+const OrderOptionsContainer = styled.View`
+  /* border: 1px solid red; */
+`;
+
+const OrderOptionItem = styled.TouchableOpacity`
+  /* border: 1px solid green; */
+  flex-direction: row;
+  align-items: center;
+  padding: 5px;
+`;
+
+const OrderOptionItemText = styled.Text`
+  color: ${(props) => props.theme.textOnSurface};
+  margin-left: 12px;
+`;
+
+// CONTAINER 2
+const RadioButtonContainer = styled.View`
+  /* flex-direction: row; */
+  /* width: 170px; */
+  margin-top: 25px;
+`;
+
+const RadioBtnItemContainer = styled.View`
+  flex-direction: row;
+  align-items: center;
+`;
+
+const styles = StyleSheet.create({
+  modalCloseIconBtn: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+  },
+  modalActionIcon: {
+    marginLeft: 10,
+  },
+  radioButtonGroup: {
+    width: 150,
+  },
+  radioButtonItem: {
+    width: 368,
+  },
+  switch: {
+    marginRight: 10,
+    marginLeft: 'auto',
+    // height: 10,
+  },
+});
+
+// CONTAINER 3
+const SaveOrderContainer = styled.View`
+  flex-direction: row;
+  align-items: center;
+  margin-top: 25px;
+  /* border: 1px solid blue; */
+  /* height: 50px; */
+`;
+
+const SaveOrderText = styled.Text`
+  color: ${(props) => props.theme.textOnSurface};
+  font-size: 15px;
+  margin-left: 14px;
+`;

--- a/thoughtbubble-mobile/src/components/ProjectDisplaySettingsModal.tsx
+++ b/thoughtbubble-mobile/src/components/ProjectDisplaySettingsModal.tsx
@@ -8,7 +8,7 @@ import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityI
 import { Overlay } from './Overlay';
 import { useDispatch } from 'react-redux';
 import { Direction, OrderType } from '../interfaces/stringLiteralTypes';
-import { OrderTypes } from '../constants/orders';
+import { Directions, OrderTypes } from '../constants/orders';
 import { UserInfoActionTypes } from '../constants/actionTypes';
 
 const { darkMode, lightMode } = colors;
@@ -23,13 +23,13 @@ export const ProjectDisplaySettingsModal: FC<ProjectDisplaySettingsModalProps> =
   setModalVisible,
 }) {
   const [order, setOrder] = useState<OrderType>('lastUpdated');
-  const [direction, setDirection] = useState<Direction>('asc');
+  const [direction, setDirection] = useState<Direction>(Directions.DESC);
   const isDarkMode = useDarkCheck();
   const dispatch = useDispatch();
 
   const handleOrderTypeChange = function (newOrder: OrderType): void {
     // dispatch an action that changes how the projects are displayed
-    if (order === newOrder) return;
+    if (newOrder === order) return;
     setOrder(newOrder);
     dispatch({
       type: UserInfoActionTypes.UPDATE_PROJ_DISPLAY,
@@ -37,9 +37,13 @@ export const ProjectDisplaySettingsModal: FC<ProjectDisplaySettingsModalProps> =
     });
   };
 
-  const handleDirectionChange = function (newDirection: Direction): void {
-    // lol
-    // reverse or not
+  const handleDirectionChange = function (): void {
+    const newDirection = direction === Directions.DESC ? Directions.ASC : Directions.DESC;
+    setDirection(newDirection);
+    dispatch({
+      type: UserInfoActionTypes.UPDATE_PROJ_DISPLAY,
+      payload: { projectOrder: order, projectDirection: newDirection },
+    });
   };
 
   const generateItemColor = function (currOrder: OrderType): string {
@@ -100,7 +104,7 @@ export const ProjectDisplaySettingsModal: FC<ProjectDisplaySettingsModalProps> =
             </OrderOptionItem>
 
             <RadioButtonContainer>
-              <RadioButton.Group onValueChange={(direction) => setDirection(direction as Direction)} value={direction}>
+              <RadioButton.Group onValueChange={() => handleDirectionChange()} value={direction}>
                 <RadioBtnItemContainer>
                   <MaterialCommunityIcons
                     name="chevron-up"

--- a/thoughtbubble-mobile/src/components/ProjectDisplaySettingsModal.tsx
+++ b/thoughtbubble-mobile/src/components/ProjectDisplaySettingsModal.tsx
@@ -6,14 +6,12 @@ import { colors } from '../constants/colors';
 import { useDarkCheck } from '../hooks/useDarkCheck';
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
 import { Overlay } from './Overlay';
+import { useDispatch } from 'react-redux';
+import { Direction, OrderType } from '../interfaces/stringLiteralTypes';
+import { OrderTypes } from '../constants/orders';
+import { UserInfoActionTypes } from '../constants/actionTypes';
 
-// const { darkMode, lightMode } = colors;
-
-type Order = 'asc' | 'desc';
-enum Orders {
-  ASC = 'asc',
-  DESC = 'desc',
-}
+const { darkMode, lightMode } = colors;
 
 interface ProjectDisplaySettingsModalProps {
   modalVisible: boolean;
@@ -24,8 +22,33 @@ export const ProjectDisplaySettingsModal: FC<ProjectDisplaySettingsModalProps> =
   modalVisible,
   setModalVisible,
 }) {
-  const [checked, setChecked] = useState<Order>('asc');
+  const [order, setOrder] = useState<OrderType>('lastUpdated');
+  const [direction, setDirection] = useState<Direction>('asc');
   const isDarkMode = useDarkCheck();
+  const dispatch = useDispatch();
+
+  const handleOrderTypeChange = function (newOrder: OrderType): void {
+    // dispatch an action that changes how the projects are displayed
+    if (order === newOrder) return;
+    setOrder(newOrder);
+    dispatch({
+      type: UserInfoActionTypes.UPDATE_PROJ_DISPLAY,
+      payload: { projectOrder: newOrder, projectDirection: direction },
+    });
+  };
+
+  const handleDirectionChange = function (newDirection: Direction): void {
+    // lol
+    // reverse or not
+  };
+
+  const generateItemColor = function (currOrder: OrderType): string {
+    if (order === currOrder) {
+      return isDarkMode ? darkMode.primary : lightMode.primary;
+    }
+    return '#808080';
+  };
+
   return (
     <>
       {modalVisible ? <Overlay /> : <></>}
@@ -39,38 +62,45 @@ export const ProjectDisplaySettingsModal: FC<ProjectDisplaySettingsModalProps> =
             style={styles.modalCloseIconBtn}
           />
           <ModalTitle>project display options</ModalTitle>
+
           <OrderOptionsContainer>
-            <OrderOptionItem>
+            <OrderOptionItem onPress={() => handleOrderTypeChange(OrderTypes.LAST_UPDATED)}>
               <MaterialCommunityIcons
                 name="clock-outline"
                 size={35}
-                color={isDarkMode ? colors.darkMode.primary : colors.lightMode.primary}
+                color={`${generateItemColor(OrderTypes.LAST_UPDATED)}`}
                 style={styles.modalActionIcon}
               />
-              <OrderOptionItemText>last updated (default)</OrderOptionItemText>
+              <OrderOptionItemText style={{ color: `${generateItemColor(OrderTypes.LAST_UPDATED)}` }}>
+                last updated (default)
+              </OrderOptionItemText>
             </OrderOptionItem>
-            <OrderOptionItem>
+            <OrderOptionItem onPress={() => handleOrderTypeChange(OrderTypes.SIZE)}>
               <MaterialCommunityIcons
                 name="sort-reverse-variant"
                 size={35}
-                color={isDarkMode ? colors.darkMode.primary : colors.lightMode.primary}
+                color={`${generateItemColor(OrderTypes.SIZE)}`}
                 style={styles.modalActionIcon}
               />
-              <OrderOptionItemText>by size</OrderOptionItemText>
+              <OrderOptionItemText style={{ color: `${generateItemColor(OrderTypes.SIZE)}` }}>
+                by size
+              </OrderOptionItemText>
             </OrderOptionItem>
-            <OrderOptionItem>
+            <OrderOptionItem onPress={() => handleOrderTypeChange(OrderTypes.ALPHABETICAL)}>
               <MaterialCommunityIcons
                 // name="sort-alphabetical-ascending-variant"
                 name="alphabetical-variant"
                 size={35}
-                color={isDarkMode ? colors.darkMode.primary : colors.lightMode.primary}
+                color={`${generateItemColor(OrderTypes.ALPHABETICAL)}`}
                 style={styles.modalActionIcon}
               />
-              <OrderOptionItemText>alphabetical</OrderOptionItemText>
+              <OrderOptionItemText style={{ color: `${generateItemColor(OrderTypes.ALPHABETICAL)}` }}>
+                alphabetical
+              </OrderOptionItemText>
             </OrderOptionItem>
 
             <RadioButtonContainer>
-              <RadioButton.Group onValueChange={(checked) => setChecked(checked as Order)} value={checked}>
+              <RadioButton.Group onValueChange={(direction) => setDirection(direction as Direction)} value={direction}>
                 <RadioBtnItemContainer>
                   <MaterialCommunityIcons
                     name="chevron-up"
@@ -134,7 +164,7 @@ const InfoModalContainer = styled.View`
 
 const ModalTitle = styled.Text`
   /* border: 1px solid red; */
-  color: grey;
+  color: ${(props) => props.theme.secondary};
   width: 250px;
   font-size: 20px;
   margin: 10px;
@@ -155,7 +185,6 @@ const OrderOptionItem = styled.TouchableOpacity`
 `;
 
 const OrderOptionItemText = styled.Text`
-  color: ${(props) => props.theme.textOnSurface};
   margin-left: 12px;
 `;
 

--- a/thoughtbubble-mobile/src/constants/actionTypes.ts
+++ b/thoughtbubble-mobile/src/constants/actionTypes.ts
@@ -10,7 +10,6 @@ export enum ActivityActionTypes {
   FETCH = 'activity/fetch',
 }
 
-// added with the archive
 export enum ProjectActionTypes {
   ARCHIVE = 'projects/archive',
   UNARCHIVE = 'projects/unarchive',
@@ -20,4 +19,8 @@ export enum ArchiveActionTypes {
   FETCH = 'archive/fetch',
   ADD_TO_ARCHIVE = 'archive/archive',
   REMOVE_FROM_UNARCHIVE = 'archive/unarchive',
+}
+
+export enum UserInfoActionTypes {
+  UPDATE_PROJ_DISPLAY = 'userInfo/updateProjectDisplay',
 }

--- a/thoughtbubble-mobile/src/constants/actionTypes.ts
+++ b/thoughtbubble-mobile/src/constants/actionTypes.ts
@@ -22,5 +22,8 @@ export enum ArchiveActionTypes {
 }
 
 export enum UserInfoActionTypes {
-  UPDATE_PROJ_DISPLAY = 'userInfo/updateProjectDisplay',
+  // UPDATE_PROJ_DISPLAY = 'userInfo/updateProjectDisplay',
+  UPDATE_ORDER = 'userInfo/updateOrder',
+  UPDATE_DIRECTION = 'userInfo/updateDirection',
+  UPDATE_SAVE_SETTING = 'userInfo/updateSaveSetting',
 }

--- a/thoughtbubble-mobile/src/constants/orders.ts
+++ b/thoughtbubble-mobile/src/constants/orders.ts
@@ -1,0 +1,9 @@
+export enum Directions {
+  ASC = 'asc',
+  DESC = 'desc',
+}
+export enum OrderTypes {
+  LAST_UPDATED = 'lastUpdated',
+  ALPHABETICAL = 'alphabetical',
+  SIZE = 'size',
+}

--- a/thoughtbubble-mobile/src/hooks/useOrderProjects.ts
+++ b/thoughtbubble-mobile/src/hooks/useOrderProjects.ts
@@ -15,13 +15,13 @@ export const useOrderProjects = function (): ProjectShape[] {
 
   if (projectOrder === OrderTypes.LAST_UPDATED) {
     // sort by last update (api returns this by default)
-    userProjectsData = [...userProjectsData.sort((a, b) => a.lastUpdatedDate.localeCompare(b.lastUpdatedDate))]; // oldest at top
+    userProjectsData = [...userProjectsData.sort((a, b) => b.lastUpdatedDate.localeCompare(a.lastUpdatedDate))]; // oldest at top
   } else if (projectOrder === OrderTypes.ALPHABETICAL) {
     // sort projects alphabetically
-    userProjectsData = [...userProjectsData.sort((a, b) => b.projectName.localeCompare(a.projectName))];
+    userProjectsData = [...userProjectsData.sort((a, b) => a.projectName.localeCompare(b.projectName))];
   } else {
     // sort projects by size (number or thoughts in them)
-    userProjectsData = [...userProjectsData.sort((a, b) => a.projectThoughts.length - b.projectThoughts.length)];
+    userProjectsData = [...userProjectsData.sort((a, b) => b.projectThoughts.length - a.projectThoughts.length)];
   }
   // format in ascending or descending order
   return projectDirection === Directions.ASC ? userProjectsData.reverse() : userProjectsData;

--- a/thoughtbubble-mobile/src/hooks/useOrderProjects.ts
+++ b/thoughtbubble-mobile/src/hooks/useOrderProjects.ts
@@ -1,0 +1,28 @@
+import { useSelector } from 'react-redux';
+
+import { Directions, OrderTypes } from '../constants/orders';
+import { ProjectShape } from '../interfaces/data';
+import { RootState } from '../reducers/rootReducer';
+
+/**
+ * fetch user's project data and order it in the way they have set i.e. alphabetically, date, etc
+ */
+export const useOrderProjects = function (): ProjectShape[] {
+  const userInfoData = useSelector((state: RootState) => state.userInfo);
+  let userProjectsData = useSelector((state: RootState) => state.userProjectData);
+  if (userProjectsData.length <= 1) return userProjectsData;
+  const { projectDirection, projectOrder } = userInfoData;
+
+  if (projectOrder === OrderTypes.LAST_UPDATED) {
+    // sort by last update (api returns this by default)
+    userProjectsData = [...userProjectsData.sort((a, b) => a.lastUpdatedDate.localeCompare(b.lastUpdatedDate))]; // oldest at top
+  } else if (projectOrder === OrderTypes.ALPHABETICAL) {
+    // sort projects alphabetically
+    userProjectsData = [...userProjectsData.sort((a, b) => b.projectName.localeCompare(a.projectName))];
+  } else {
+    // sort projects by size (number or thoughts in them)
+    userProjectsData = [...userProjectsData.sort((a, b) => a.projectThoughts.length - b.projectThoughts.length)];
+  }
+  // format in ascending or descending order
+  return projectDirection === Directions.ASC ? userProjectsData.reverse() : userProjectsData;
+};

--- a/thoughtbubble-mobile/src/interfaces/data.ts
+++ b/thoughtbubble-mobile/src/interfaces/data.ts
@@ -1,4 +1,17 @@
-import { Locations } from './stringLiteralTypes';
+import { Direction, Locations, OrderType } from './stringLiteralTypes';
+
+export interface UserInfoShape {
+  // from query on User entity table
+  id: string;
+  email: string;
+  username: string;
+  githubId: string;
+  dailyEmail: boolean;
+  weeklyEmail: boolean;
+  darkMode: boolean;
+  projectOrder: OrderType;
+  projectDirection: Direction;
+}
 
 export interface ThoughtShape {
   id: string;

--- a/thoughtbubble-mobile/src/interfaces/data.ts
+++ b/thoughtbubble-mobile/src/interfaces/data.ts
@@ -11,6 +11,7 @@ export interface UserInfoShape {
   darkMode: boolean;
   projectOrder: OrderType;
   projectDirection: Direction;
+  saveOrder: boolean;
 }
 
 export interface ThoughtShape {

--- a/thoughtbubble-mobile/src/interfaces/stringLiteralTypes.ts
+++ b/thoughtbubble-mobile/src/interfaces/stringLiteralTypes.ts
@@ -1,3 +1,5 @@
 export type StatusFilters = 'all' | 'incomplete' | 'completed';
 export type Locations = 'mobile' | 'vscode';
 export type ActivityRanges = '1W' | '1M' | '3M' | '6M' | '1Y';
+export type Direction = 'asc' | 'desc';
+export type OrderType = 'lastUpdated' | 'size' | 'alphabetical';

--- a/thoughtbubble-mobile/src/reducers/userInfoReducer.ts
+++ b/thoughtbubble-mobile/src/reducers/userInfoReducer.ts
@@ -1,13 +1,6 @@
-interface UserInfoShape {
-  // from query on User entity table
-  id: string;
-  email: string;
-  username: string;
-  githubId: string;
-  dailyEmail: boolean;
-  weeklyEmail: boolean;
-  darkMode: boolean;
-}
+import { UserInfoShape } from '../interfaces/data';
+import { Directions, OrderTypes } from '../constants/orders';
+import { UserInfoActionTypes } from '../constants/actionTypes';
 
 const initialState: UserInfoShape = {
   id: '',
@@ -17,12 +10,15 @@ const initialState: UserInfoShape = {
   dailyEmail: true,
   weeklyEmail: true,
   darkMode: true,
+  projectOrder: OrderTypes.LAST_UPDATED,
+  projectDirection: Directions.DESC,
 };
 
 export const userInfoReducer = (state = initialState, action): UserInfoShape => {
-  switch (action.type) {
+  const { payload, type } = action;
+  switch (type) {
     case 'fetchUserInfo':
-      return action.payload;
+      return payload;
     case 'toggleDailyEmail':
       return {
         ...state,
@@ -38,6 +34,14 @@ export const userInfoReducer = (state = initialState, action): UserInfoShape => 
         ...state,
         darkMode: !state.darkMode,
       };
+    // new bois
+    // payload: { orderType: type, direction: direction }
+    case UserInfoActionTypes.UPDATE_PROJ_DISPLAY:
+      return { ...state, projectOrder: payload.projectOrder, projectDirection: payload.projectDirection };
+    // case UserInfoActionTypes.UPDATE_PROJ_ORDER:
+    //   return { ...state, projectOrder: payload };
+    // case UserInfoActionTypes.UPDATE_PROJ_DIRECTION:
+    //   return { ...state, projectDirection: payload };
     default:
       return state;
   }

--- a/thoughtbubble-mobile/src/reducers/userInfoReducer.ts
+++ b/thoughtbubble-mobile/src/reducers/userInfoReducer.ts
@@ -34,14 +34,8 @@ export const userInfoReducer = (state = initialState, action): UserInfoShape => 
         ...state,
         darkMode: !state.darkMode,
       };
-    // new bois
-    // payload: { orderType: type, direction: direction }
     case UserInfoActionTypes.UPDATE_PROJ_DISPLAY:
       return { ...state, projectOrder: payload.projectOrder, projectDirection: payload.projectDirection };
-    // case UserInfoActionTypes.UPDATE_PROJ_ORDER:
-    //   return { ...state, projectOrder: payload };
-    // case UserInfoActionTypes.UPDATE_PROJ_DIRECTION:
-    //   return { ...state, projectDirection: payload };
     default:
       return state;
   }

--- a/thoughtbubble-mobile/src/reducers/userInfoReducer.ts
+++ b/thoughtbubble-mobile/src/reducers/userInfoReducer.ts
@@ -12,6 +12,7 @@ const initialState: UserInfoShape = {
   darkMode: true,
   projectOrder: OrderTypes.LAST_UPDATED,
   projectDirection: Directions.DESC,
+  saveOrder: false,
 };
 
 export const userInfoReducer = (state = initialState, action): UserInfoShape => {
@@ -34,8 +35,12 @@ export const userInfoReducer = (state = initialState, action): UserInfoShape => 
         ...state,
         darkMode: !state.darkMode,
       };
-    case UserInfoActionTypes.UPDATE_PROJ_DISPLAY:
-      return { ...state, projectOrder: payload.projectOrder, projectDirection: payload.projectDirection };
+    case UserInfoActionTypes.UPDATE_ORDER:
+      return { ...state, projectOrder: payload };
+    case UserInfoActionTypes.UPDATE_DIRECTION:
+      return { ...state, projectDirection: payload };
+    case UserInfoActionTypes.UPDATE_SAVE_SETTING:
+      return { ...state, saveOrder: !state.saveOrder };
     default:
       return state;
   }

--- a/thoughtbubble-mobile/src/screens/ProjectsScreen.tsx
+++ b/thoughtbubble-mobile/src/screens/ProjectsScreen.tsx
@@ -1,27 +1,27 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { Text, StyleSheet, LogBox, Animated } from 'react-native';
+import { StyleSheet, LogBox, Animated } from 'react-native';
 import { useSelector } from 'react-redux';
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
 import { FAB, IconButton } from 'react-native-paper';
+import styled, { ThemeProvider } from 'styled-components/native';
+
 import { RootState } from '../reducers/rootReducer'; // type
 import { ProjectsScreenProps } from '../interfaces/componentProps'; // type
 import { colors } from '../constants/colors';
 import { AddProjectModal } from '../components/AddProjectModal';
 import { useDarkCheck } from '../hooks/useDarkCheck';
-import styled, { ThemeProvider } from 'styled-components/native';
+import { useOrderProjects } from '../hooks/useOrderProjects';
 import { ProjectList } from '../components/ProjectList';
 import { EmptyPlaceholder } from '../components/EmptyPlaceholder';
 import { ProjectDisplaySettingsModal } from '../components/ProjectDisplaySettingsModal';
 
 const { darkMode, lightMode } = colors;
-const data = [];
-for (let i = 0; i < 5; i++) data.push(Math.random());
 
 export const ProjectsScreen: React.FC<ProjectsScreenProps> = ({ navigation }) => {
   const [addProjModalView, setAddProjModalView] = useState(false);
   const [projectSettingsModal, setProjectSettingsModal] = useState(false);
   const isDarkMode = useDarkCheck();
-  let userProjectsData = useSelector((state: RootState) => state.userProjectData);
+  let userProjectsData = useOrderProjects();
 
   const theme = {
     // for styled-components ThemeProvider

--- a/thoughtbubble-mobile/src/screens/ProjectsScreen.tsx
+++ b/thoughtbubble-mobile/src/screens/ProjectsScreen.tsx
@@ -1,8 +1,8 @@
-import React, { useState, useEffect, useRef, memo, useCallback } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Text, StyleSheet, LogBox, Animated } from 'react-native';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
-import { FAB } from 'react-native-paper';
+import { FAB, IconButton } from 'react-native-paper';
 import { RootState } from '../reducers/rootReducer'; // type
 import { ProjectsScreenProps } from '../interfaces/componentProps'; // type
 import { colors } from '../constants/colors';
@@ -11,8 +11,7 @@ import { useDarkCheck } from '../hooks/useDarkCheck';
 import styled, { ThemeProvider } from 'styled-components/native';
 import { ProjectList } from '../components/ProjectList';
 import { EmptyPlaceholder } from '../components/EmptyPlaceholder';
-
-// const ProjectListMemo = memo(ProjectList);
+import { ProjectDisplaySettingsModal } from '../components/ProjectDisplaySettingsModal';
 
 const { darkMode, lightMode } = colors;
 const data = [];
@@ -20,6 +19,7 @@ for (let i = 0; i < 5; i++) data.push(Math.random());
 
 export const ProjectsScreen: React.FC<ProjectsScreenProps> = ({ navigation }) => {
   const [addProjModalView, setAddProjModalView] = useState(false);
+  const [projectSettingsModal, setProjectSettingsModal] = useState(false);
   const isDarkMode = useDarkCheck();
   let userProjectsData = useSelector((state: RootState) => state.userProjectData);
 
@@ -91,6 +91,10 @@ export const ProjectsScreen: React.FC<ProjectsScreenProps> = ({ navigation }) =>
     };
   });
 
+  const openProjectSettingsModal = useCallback(() => {
+    setProjectSettingsModal(true);
+  }, []);
+
   // for dev https://github.com/jemise111/react-native-swipe-list-view/issues/388
   LogBox.ignoreLogs(["Sending 'onAnimatedValueUpdate' with no listeners registered"]);
 
@@ -124,6 +128,13 @@ export const ProjectsScreen: React.FC<ProjectsScreenProps> = ({ navigation }) =>
           >
             Projects
           </Animated.Text>
+          <IconButton
+            icon="tune"
+            onPress={() => openProjectSettingsModal()}
+            size={30}
+            color={theme ? colors.darkMode.primary : colors.lightMode.textOnPrimary}
+            style={styles.tuneIcon}
+          />
           <Animated.View
             style={[
               headerStyles.bottomBorder,
@@ -139,6 +150,7 @@ export const ProjectsScreen: React.FC<ProjectsScreenProps> = ({ navigation }) =>
         )}
       </MainContainer>
       <AddProjectModal addProjModalView={addProjModalView} setAddProjModalView={setAddProjModalView} />
+      <ProjectDisplaySettingsModal modalVisible={projectSettingsModal} setModalVisible={setProjectSettingsModal} />
       <FAB style={styles.fab} icon="plus" onPress={() => setAddProjModalView(true)} label="new project" />
     </ThemeProvider>
   );
@@ -192,5 +204,13 @@ const styles = StyleSheet.create({
     right: 0,
     bottom: 80,
     margin: 16,
+  },
+  tuneIcon: {
+    position: 'absolute',
+    bottom: -5,
+    right: 10,
+    borderRadius: 10,
+    width: 35,
+    height: 35,
   },
 });

--- a/thoughtbubble-mobile/src/screens/ThoughtsScreen.tsx
+++ b/thoughtbubble-mobile/src/screens/ThoughtsScreen.tsx
@@ -165,15 +165,7 @@ export const ThoughtsScreen: FC<ThoughtScreenProps> = ({ route, navigation }) =>
               onPress={() => setSortModalView(true)}
               size={35}
               color={theme ? colors.darkMode.primary : colors.lightMode.textOnPrimary}
-              style={{
-                position: 'absolute',
-                bottom: -5,
-                right: 10,
-                // backgroundColor: darkMode.dp1,
-                borderRadius: 10,
-                width: 35,
-                height: 35,
-              }}
+              style={styles.sortIcon}
             />
             <Animated.View
               style={[
@@ -266,5 +258,13 @@ const styles = StyleSheet.create({
     right: 0,
     bottom: 80,
     margin: 16,
+  },
+  sortIcon: {
+    position: 'absolute',
+    bottom: -5,
+    right: 10,
+    borderRadius: 10,
+    width: 35,
+    height: 35,
   },
 });


### PR DESCRIPTION
- create icon in header on projects page that opens "order and sort" bottom sheet
- can then sort projects alphabetically, by date, or by size and in high to low or low to high order
- settings switch to opt into saving your order settings for next time
- 3 new api endpoints and controller methods added to api
- User entity gained 3 columns, projectOrder, projectDirection, saveOrder
- redux integrations completed on the front end
- styled bottom sheet most the way, needs uniform use of full length radio buttons in the future